### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ A Lightroom Classic plugin created with Lightroom SDK which uploads images to an
 Download the current release zip file and extract it to the Lightroom plugin folder, which is:
 
 Mac
-    /Users/$USER/Library/Application Support/Adobe/Lightroom/Modules/
+    `/Users/$USER/Library/Application Support/Adobe/Lightroom/Modules/`
 
 Windows
-    C:\Users\%USERNAME%\AppData\Roaming\Adobe\Lightroom\Modules on Windows
+    `C:\Users\%USERNAME%\AppData\Roaming\Adobe\Lightroom\Modules`
 
 Alternatively extract it somewhere good an go to Lightroom Module Manager and add it via the GUI.
 


### PR DESCRIPTION
`\%` in Windows path required escaping for it to be displayed properly (for copy-pasting), but I think that putting both paths in code blocks will be better as it does not require thinking about any character escaping in case the path will need to be updated.