### PR TITLE
Check if asset exists with filename and createDate

### DIFF
--- a/immich-export.lrdevplugin/ImmichAPI.lua
+++ b/immich-export.lrdevplugin/ImmichAPI.lua
@@ -244,7 +244,7 @@ function ImmichAPI:getAlbums()
 end
 
 
-function ImmichAPI:checkIfAssetExists(localId)
+function ImmichAPI:checkIfAssetExists(localId, filename, dateCreated)
 
     local id = tostring(localId)
 
@@ -252,11 +252,24 @@ function ImmichAPI:checkIfAssetExists(localId)
     local response = ImmichAPI:doPostRequest('/search/metadata', postBody)
 
     if not response then
-        log:trace('Asset with assetDeviceId ' .. id .. ' not found')
-        return nil
+        log:trace('Asset with assetDeviceId ' .. id .. ' not found. No response')
+		return nil
     elseif response.assets.count >= 1 then
         log:trace('Found existing asset with assetDeviceId ' .. tostring(localId))
-        return response.assets.items[1].id
+        return response.assets.items[1].id, response.assets.items[1].deviceAssetId
+	else
+		log:trace('In Asset with assetDeviceId ' .. id .. ' not found')
+		
+		postBody = { originalFileName = filename, takenAfter = dateCreated, takenBefore = dateCreated, isTrashed = false }
+		response = ImmichAPI:doPostRequest('/search/metadata', postBody)
+		
+		if not response then
+			log:trace('No asset with originalFilename ' .. filename .. ' and creationDate ' .. dateCreated .. ' found')
+			return nil
+		elseif response.assets.count >= 1 then
+			log:trace('Found existing asset with filename  ' .. filename .. ' and creationDate ' ..  dateCreated)
+			return response.assets.items[1].id, response.assets.items[1].deviceAssetId 
+		end
     end
 end
 

--- a/immich-export.lrdevplugin/ImmichUploadTask.lua
+++ b/immich-export.lrdevplugin/ImmichUploadTask.lua
@@ -161,13 +161,13 @@ function ImmichUploadTask.processRenderedPhotos(functionContext, exportContext)
         if progressScope:isCanceled() then break end
         
         if success then
-            local existingId = immich:checkIfAssetExists(rendition.photo.localIdentifier)
+            local existingId, existingDeviceId = immich:checkIfAssetExists(rendition.photo.localIdentifier, rendition.photo:getFormattedMetadata( "fileName" ), rendition.photo:getFormattedMetadata( "dateCreated" ))
             local id
 
             if existingId == nil then
                 id = immich:uploadAsset(pathOrMessage, rendition.photo.localIdentifier)
             else
-                id = immich:replaceAsset(existingId, pathOrMessage, rendition.photo.localIdentifier)
+                id = immich:replaceAsset(existingId, pathOrMessage, existingDeviceId)
                 -- id = immich:uploadAsset(pathOrMessage, rendition.photo.localIdentifier)
             end
 


### PR DESCRIPTION
A suggestion for an additional comparison with the existing photos in Immich. So that no duplicates are created:

If the asset was not found in Immich with the assetDeviceId, the system also checks whether an asset with the same file name and creation date already exists. If this is the case, the assetDeviceId is adopted.