### PR TITLE
fix: replaceAsset returns the assetid

### DIFF
--- a/immich-plugin.lrplugin/ImmichAPI.lua
+++ b/immich-plugin.lrplugin/ImmichAPI.lua
@@ -199,7 +199,7 @@ function ImmichAPI:replaceAsset(immichId, pathOrMessage, localId)
 
 	-- log:trace('uploadAsset: mimeChunks' .. util.dumpTable(mimeChunks))
     parsedResponse = ImmichAPI:doMultiPartPutRequest(apiPath, pathOrMessage, formData)
-    return parsedResponse.id
+    return immichId
 end
 
 function ImmichAPI:removeAssetFromAlbum(albumId, assetId)


### PR DESCRIPTION
Currently replaced images are not added to the album because the AssetId is wrong.

The Immich Replace-Asset API call does not return the AssetId but copiedPhoto.id (https://github.com/immich-app/immich/blob/aa04ded311985a6f8176217e47a7af89b7ea425d/server/src/services/asset-media.service.ts#L212), which doesn't make much sense from my point of view. But since we already know the AssetId, the AssetId is simply returned again.