### PR TITLE
Allow use of more than one Immich connection.

### DIFF
--- a/immich-plugin.lrplugin/ExportServiceProvider.lua
+++ b/immich-plugin.lrplugin/ExportServiceProvider.lua
@@ -20,7 +20,7 @@ return {
 
 	startDialog = ExportDialogSections.startDialog,
 	sectionsForTopOfDialog = ExportDialogSections.sectionsForTopOfDialog,
-	-- sectionsForBottomOfDialog = ExportDialogSections.sectionsForBottomOfDialog,
+	sectionsForBottomOfDialog = ExportDialogSections.sectionsForBottomOfDialog,
 
 	processRenderedPhotos = ExportTask.processRenderedPhotos,
 

--- a/immich-plugin.lrplugin/ExportServiceProvider.lua
+++ b/immich-plugin.lrplugin/ExportServiceProvider.lua
@@ -10,8 +10,8 @@ return {
 	allowColorSpaces = nil,
 
 	exportPresetFields = {
-		-- { key = 'url', default = prefs.url },
-		-- { key = "apiKey", default = prefs.apiKey },
+		{ key = 'url', default = '' },
+		{ key = "apiKey", default = '' },
 		{ key = 'album',     default = nil },
 		{ key = 'albumMode', default = nil },
 	},

--- a/immich-plugin.lrplugin/ExportTask.lua
+++ b/immich-plugin.lrplugin/ExportTask.lua
@@ -8,13 +8,16 @@ ExportTask = {}
 --------------------------------------------------------------------------------
 
 function ExportTask.processRenderedPhotos(functionContext, exportContext)
-    if not immich:checkConnectivity() then
-        LrDialogs.showError('Immich connection not set up.')
-        return nil
-    end
     -- Make a local reference to the export parameters.
     local exportSession = exportContext.exportSession
     local exportParams = exportContext.propertyTable
+
+    local immich = ImmichAPI:new(exportParams.url, exportParams.apiKey)
+    if not immich:checkConnectivity() then
+        util.handleError('Immich connection not working, probably due to wrong url and/or apiKey. Export stopped.', 
+            'Immich connection not working, probably due to wrong url and/or apiKey. Export stopped.')
+        return nil
+    end
 
     -- Set progress title.
     local nPhotos = exportSession:countRenditions()

--- a/immich-plugin.lrplugin/ImmichAPI.lua
+++ b/immich-plugin.lrplugin/ImmichAPI.lua
@@ -543,5 +543,3 @@ function ImmichAPI.immichConnected()
     end
 end
 
--- Global instance of connection to immich.
-_G.immich = ImmichAPI:new(prefs.url, prefs.apiKey)

--- a/immich-plugin.lrplugin/Info.lua
+++ b/immich-plugin.lrplugin/Info.lua
@@ -26,6 +26,6 @@ return {
 
 	LrPluginInfoURL = 'https://github.com/bmachek/lrc-immich-plugin',
 
-	VERSION = { major = 2, minor = 0, revision = 1, build = "", },
+	VERSION = { major = 2, minor = 1, revision = 0, build = "", },
 
 }

--- a/immich-plugin.lrplugin/PluginInfo.lua
+++ b/immich-plugin.lrplugin/PluginInfo.lua
@@ -4,6 +4,6 @@ return {
     startDialog = PluginInfoDialogSections.startDialog,
     endDialog = PluginInfoDialogSections.endDialog,
 
-    sectionsForTopOfDialog = PluginInfoDialogSections.sectionsForTopOfDialog,
+    -- sectionsForTopOfDialog = PluginInfoDialogSections.sectionsForTopOfDialog,
     sectionsForBottomOfDialog = PluginInfoDialogSections.sectionsForBottomOfDialog,
 }

--- a/immich-plugin.lrplugin/PluginInfoDialogSections.lua
+++ b/immich-plugin.lrplugin/PluginInfoDialogSections.lua
@@ -3,106 +3,11 @@ require "ImmichAPI"
 PluginInfoDialogSections = {}
 
 
-
-function storeValue(propertyTable, key, val)
-    if key == 'url' then
-        propertyTable.immich.url(val)
-    elseif key == 'apiKey' then
-        propertyTable.immich.apiKey(val)
-    end
-end
-
-function PluginInfoDialogSections.sectionsForTopOfDialog(f, propertyTable)
-    local bind = LrView.bind
-    local share = LrView.share
-
-    return {
-
-        {
-            bind_to_object = propertyTable,
-
-            title = "Immich Server Connection",
-
-            f:row {
-                f:static_text {
-                    title = "URL:",
-                    alignment = 'right',
-                    width = share 'labelWidth'
-                },
-                f:edit_field {
-                    value = bind 'url',
-                    truncation = 'middle',
-                    immediate = true,
-                    width_in_chars = 40,
-                    validate = function(v, url)
-                        sanitizedURL = propertyTable.immich:sanityCheckAndFixURL(url)
-                        if sanitizedURL == url then
-                            return true, url, ''
-                        elseif not (sanitizedURL == nil) then
-                            LrDialogs.message('Entered URL was autocorrected to ' .. sanitizedURL)
-                            return true, sanitizedURL, ''
-                        end
-                        return false, url, 'Entered URL not valid.\nShould look like https://demo.immich.app'
-                    end,
-                },
-                f:push_button {
-                    title = 'Test connection',
-                    action = function(button)
-                        LrTasks.startAsyncTask(function()
-                            local testImmich = ImmichAPI:new(propertyTable.url, propertyTable.apiKey)
-                            if testImmich:checkConnectivity() then
-                                LrDialogs.message('Connection test successful')
-                            else
-                                LrDialogs.message('Connection test NOT successful')
-                            end
-                        end)
-                    end,
-                },
-            },
-
-            f:row {
-                f:static_text {
-                    title = "API Key:",
-                    alignment = 'right',
-                    width = share 'labelWidth',
-                    visible = bind 'hasNoError',
-                },
-                f:password_field {
-                    value = bind 'apiKey',
-                    truncation = 'middle',
-                    immediate = true,
-                    width_in_chars = 40,
-                },
-            },
-        },
-    }
-end
-
 function PluginInfoDialogSections.startDialog(propertyTable)
-    -- if prefs.url == nil then
-    --     prefs.url = ''
-    -- end
-
-    -- if prefs.apiKey == nil then
-    --     prefs.apiKey = ''
-    -- end
-
     if prefs.logging == nil then
         prefs.logging = false
     end
-
-    -- propertyTable.url = prefs.url
-    -- propertyTable.apiKey = prefs.apiKey
     propertyTable.logging = prefs.logging
-
-    -- propertyTable:addObserver('url', storeValue)
-    -- propertyTable:addObserver('apiKey', storeValue)
-
-    -- if propertyTable.url and propertyTable.apiKey then
-    --     LrTasks.startAsyncTask(function()
-    --         propertyTable.immich = ImmichAPI:new(prefs.url, prefs.apiKey)
-    --     end)
-    -- end
 end
 
 function PluginInfoDialogSections.sectionsForBottomOfDialog(f, propertyTable)
@@ -131,11 +36,6 @@ function PluginInfoDialogSections.sectionsForBottomOfDialog(f, propertyTable)
 end
 
 function PluginInfoDialogSections.endDialog(propertyTable)
-    prefs.apiKey = propertyTable.apiKey
-    prefs.url = propertyTable.url
-
-    immich:reconfigure(prefs.url, prefs.apiKey)
-
     prefs.logging = propertyTable.logging
     if propertyTable.logging then
         log:enable('logfile')

--- a/immich-plugin.lrplugin/PluginInfoDialogSections.lua
+++ b/immich-plugin.lrplugin/PluginInfoDialogSections.lua
@@ -79,30 +79,30 @@ function PluginInfoDialogSections.sectionsForTopOfDialog(f, propertyTable)
 end
 
 function PluginInfoDialogSections.startDialog(propertyTable)
-    if prefs.url == nil then
-        prefs.url = ''
-    end
+    -- if prefs.url == nil then
+    --     prefs.url = ''
+    -- end
 
-    if prefs.apiKey == nil then
-        prefs.apiKey = ''
-    end
+    -- if prefs.apiKey == nil then
+    --     prefs.apiKey = ''
+    -- end
 
     if prefs.logging == nil then
         prefs.logging = false
     end
 
-    propertyTable.url = prefs.url
-    propertyTable.apiKey = prefs.apiKey
+    -- propertyTable.url = prefs.url
+    -- propertyTable.apiKey = prefs.apiKey
     propertyTable.logging = prefs.logging
 
-    propertyTable:addObserver('url', storeValue)
-    propertyTable:addObserver('apiKey', storeValue)
+    -- propertyTable:addObserver('url', storeValue)
+    -- propertyTable:addObserver('apiKey', storeValue)
 
-    if propertyTable.url and propertyTable.apiKey then
-        LrTasks.startAsyncTask(function()
-            propertyTable.immich = ImmichAPI:new(prefs.url, prefs.apiKey)
-        end)
-    end
+    -- if propertyTable.url and propertyTable.apiKey then
+    --     LrTasks.startAsyncTask(function()
+    --         propertyTable.immich = ImmichAPI:new(prefs.url, prefs.apiKey)
+    --     end)
+    -- end
 end
 
 function PluginInfoDialogSections.sectionsForBottomOfDialog(f, propertyTable)

--- a/immich-plugin.lrplugin/PublishServiceProvider.lua
+++ b/immich-plugin.lrplugin/PublishServiceProvider.lua
@@ -2,7 +2,7 @@ require "PublishDialogSections"
 require "PublishTask"
 
 return {
-
+	sectionsForTopOfDialog = PublishDialogSections.sectionsForTopOfDialog,
 	hideSections = { 'exportLocation' },
 	allowFileFormats = nil,
 	allowColorSpaces = nil,

--- a/immich-plugin.lrplugin/PublishServiceProvider.lua
+++ b/immich-plugin.lrplugin/PublishServiceProvider.lua
@@ -2,6 +2,7 @@ require "PublishDialogSections"
 require "PublishTask"
 
 return {
+	startDialog = PublishDialogSections.startDialog,
 	sectionsForTopOfDialog = PublishDialogSections.sectionsForTopOfDialog,
 	hideSections = { 'exportLocation' },
 	allowFileFormats = nil,
@@ -9,6 +10,12 @@ return {
 	canExportVideo = true,
 	supportsCustomSortOrder = false,
 	supportsIncrementalPublish = 'only',
+
+
+	exportPresetFields = {
+		{ key = 'url', default = '' },
+		{ key = "apiKey", default = '' },
+	},
 
 	small_icon = 'icons/logo_small.png',
 

--- a/immich-plugin.lrplugin/PublishTask.lua
+++ b/immich-plugin.lrplugin/PublishTask.lua
@@ -4,13 +4,17 @@ require "ImmichAPI"
 PublishTask = {}
 
 function PublishTask.processRenderedPhotos(functionContext, exportContext)
-    if not ImmichAPI.immichConnected() then
-        LrDialogs.showError('Immich connection not set up.')
+    local exportSession = exportContext.exportSession
+    local exportParams = exportContext.propertyTable
+
+
+    local immich = ImmichAPI:new(exportParams.url, exportParams.apiKey)
+    if not immich:checkConnectivity() then
+        util.handleError('Immich connection not working, probably due to wrong url and/or apiKey. Export stopped.', 
+            'Immich connection not working, probably due to wrong url and/or apiKey. Export stopped.')
         return nil
     end
 
-    local exportSession = exportContext.exportSession
-    local exportParams = exportContext.propertyTable
     local publishedCollection = exportContext.publishedCollection
     local albumId = publishedCollection:getRemoteId()
     local albumName = publishedCollection:getName()
@@ -89,6 +93,13 @@ function PublishTask.addCommentToPublishedPhoto(publishSettings, remotePhotoId, 
 end
 
 function PublishTask.getCommentsFromPublishedCollection(publishSettings, arrayOfPhotoInfo, commentCallback)
+    local immich = ImmichAPI:new(publishSettings.url, publishSettings.apiKey)
+    if not immich:checkConnectivity() then
+        util.handleError('Immich connection not working, probably due to wrong url and/or apiKey. Export stopped.', 
+            'Immich connection not working, probably due to wrong url and/or apiKey. Export stopped.')
+        return nil
+    end
+
     for i, photoInfo in ipairs(arrayOfPhotoInfo) do
         -- Get all published Collections where the photo is included.
         local publishedCollections = photoInfo.photo:getContainedPublishedCollections()
@@ -129,10 +140,11 @@ function PublishTask.getCommentsFromPublishedCollection(publishSettings, arrayOf
     end
 end
 
-function PublishTask.deletePhotosFromPublishedCollection(publishSettings, arrayOfPhotoIds, deletedCallback,
-                                                         localCollectionId)
+function PublishTask.deletePhotosFromPublishedCollection(publishSettings, arrayOfPhotoIds, deletedCallback, localCollectionId)
+   local immich = ImmichAPI:new(publishSettings.url, publishSettings.apiKey)
     if not immich:checkConnectivity() then
-        LrDialogs.showError('Immich connection not set up.')
+        util.handleError('Immich connection not working, probably due to wrong url and/or apiKey. Export stopped.', 
+            'Immich connection not working, probably due to wrong url and/or apiKey. Export stopped.')
         return nil
     end
 
@@ -147,10 +159,13 @@ function PublishTask.deletePhotosFromPublishedCollection(publishSettings, arrayO
 end
 
 function PublishTask.deletePublishedCollection(publishSettings, info)
+    local immich = ImmichAPI:new(publishSettings.url, publishSettings.apiKey)
     if not immich:checkConnectivity() then
-        LrDialogs.showError('Immich connection not set up.')
+        util.handleError('Immich connection not working, probably due to wrong url and/or apiKey. Export stopped.', 
+            'Immich connection not working, probably due to wrong url and/or apiKey. Export stopped.')
         return nil
     end
+
     -- remoteId is nil, if the collection isn't yet published.
     if info.remoteId ~= nil then
         ImmichAPI:deleteAlbum(info.remoteId)
@@ -158,8 +173,10 @@ function PublishTask.deletePublishedCollection(publishSettings, info)
 end
 
 function PublishTask.renamePublishedCollection(publishSettings, info)
+    local immich = ImmichAPI:new(publishSettings.url, publishSettings.apiKey)
     if not immich:checkConnectivity() then
-        LrDialogs.showError('Immich connection not set up.')
+        util.handleError('Immich connection not working, probably due to wrong url and/or apiKey. Export stopped.', 
+            'Immich connection not working, probably due to wrong url and/or apiKey. Export stopped.')
         return nil
     end
 

--- a/immich-plugin.lrplugin/util.lua
+++ b/immich-plugin.lrplugin/util.lua
@@ -16,8 +16,8 @@ end
 -- Utility function to dump tables as JSON scrambling the API key.
 function util.dumpTable(t)
     local s = inspect(t)
-    local pattern = '(field = "x%-api%-key",%s+value = ")%w+(")'
-    return s:gsub(pattern, '%1xxx%2')
+    local pattern = '(field = "x%-api%-key",%s+value = ")(%w%w%w%w%w%w%w%w%w%w%w)(%w+)(")'
+    return s:gsub(pattern, '%1%2...%4')
 end
 
 -- Utility function to log errors and throw user errors
@@ -39,4 +39,8 @@ function util.nilOrEmpty(val)
     else
         return val == nil
     end
+end
+
+function util.cutApiKey(key)
+    return string.sub(key, 1, 20) .. '...'
 end


### PR DESCRIPTION
It should be possible to configure more than one Immich connection.
In order to do so, configuration has been moved (back) to the export presets/publish service settings.

Please note that this is a breaking change: Export presets and publish services need to reconfigured in Lightroom to work.

Requested in #27 
