### PR TITLE
#65 Live photos implementation 

### DIFF
--- a/immich-plugin.lrplugin/ImmichAPI.lua
+++ b/immich-plugin.lrplugin/ImmichAPI.lua
@@ -87,6 +87,62 @@ function ImmichAPI:downloadAsset(assetId)
     end
 end
 
+function ImmichAPI:hasLivePhotoVideo(assetId)
+    if util.nilOrEmpty(assetId) then
+        util.handleError('hasLivePhotoVideo: assetId empty', 'No asset ID provided. Check logs.')
+        return nil
+    end
+
+    local path = '/assets/' .. assetId
+    local parsedResponse = ImmichAPI.doGetRequest(self, path)
+
+    if parsedResponse ~= nil and parsedResponse.livePhotoVideoId then
+        log:trace("Asset has live photo video ID: " .. parsedResponse.livePhotoVideoId)
+        return true
+    else
+        log:trace("Asset does not have a live photo video ID.")
+        return false
+    end
+end
+
+function ImmichAPI:getLivePhotoVideoId(assetId)
+    if util.nilOrEmpty(assetId) then
+        util.handleError('getLivePhotoVideoId: assetId empty', 'No asset ID provided. Check logs.')
+        return nil
+    end
+
+    local path = '/assets/' .. assetId
+    local parsedResponse = ImmichAPI.doGetRequest(self, path)
+
+    if parsedResponse ~= nil and parsedResponse.livePhotoVideoId then
+        log:trace("Live photo video ID: " .. parsedResponse.livePhotoVideoId)
+        return parsedResponse.livePhotoVideoId
+    else
+        log:trace("No live photo video ID found.")
+        return nil
+    end
+end
+
+function ImmichAPI:getOriginalFileName(assetId)
+    if util.nilOrEmpty(assetId) then
+        util.handleError('getOriginalFileName: assetId empty', 'No asset ID provided. Check logs.')
+        return nil
+    end
+
+    local path = '/assets/' .. assetId
+    local parsedResponse = ImmichAPI.doGetRequest(self, path)
+
+    if parsedResponse ~= nil and parsedResponse.originalFileName then
+        log:trace("Original file name: " .. parsedResponse.originalFileName)
+        return parsedResponse.originalFileName
+    else
+        log:trace("No original file name found.")
+        return nil
+    end
+end
+
+
+
 function ImmichAPI:getAlbumAssets(albumId)
     if util.nilOrEmpty(albumId) then
         util.handleError('getAlbumAssets: albumId empty', 'No album ID provided. Check logs.')

--- a/immich-plugin.lrplugin/ImportServiceProvider.lua
+++ b/immich-plugin.lrplugin/ImportServiceProvider.lua
@@ -54,6 +54,26 @@ local function downloadAlbumAssets(immichAPI, albumId, myPath)
                 LrDialogs.message("Error", TITLES.ERROR_DOWNLOAD .. asset.id, "critical")
             end
 
+            if immichAPI:hasLivePhotoVideo(asset.id) then
+                local livePhotoVideoId = immichAPI:getLivePhotoVideoId(asset.id)
+                if livePhotoVideoId then
+                    local livePhotoVideoData = immichAPI:downloadAsset(livePhotoVideoId)
+                    if livePhotoVideoData then
+                        local tempFilePath = LrPathUtils.child(myPath, immichAPI:getOriginalFileName(livePhotoVideoId))
+                        local file = io.open(tempFilePath, "wb")
+
+                        if file then
+                            file:write(livePhotoVideoData)
+                            file:close()
+                        else
+                            LrDialogs.message("Error", TITLES.ERROR_SAVE_FILE, "critical")
+                        end
+                    else
+                        LrDialogs.message("Error", TITLES.ERROR_DOWNLOAD .. livePhotoVideoId, "critical")
+                    end
+                end
+            end
+
             -- Increment the completed task counter in a thread-safe manner
             completedTasks = completedTasks + 1
 


### PR DESCRIPTION
After some test the plugin is able to import the .mov file form Live Photos. 

Not 100% happy with the implementation since it needs to make an extra http request for every asset validating if it has live photos. Than if it has live photos it downloads the asset.  

For an next version the getAlbumAssets the table that it returns can have an extra boolean atribute to validate if it has live photos avoiding the extra http request 