### PR TITLE
Feature : Stack Original Files in Immich.

### DIFF
--- a/immich-plugin.lrplugin/ExportDialogSections.lua
+++ b/immich-plugin.lrplugin/ExportDialogSections.lua
@@ -40,6 +40,39 @@ function ExportDialogSections.sectionsForBottomOfDialog(f, propertyTable)
 	local result = {
 
 		{
+			title = "Keep Original Files in Immich",
+			f:column {
+				f:row {
+					f:static_text {
+						title = "Upload original files alongside edited exports to create stacks in Immich.",
+						alignment = 'left',
+						text_color = LrColor( 0.6, 0.6, 0.6 ),
+						font = '<system/small>',
+					},
+				},
+				f:row {
+					f:static_text {
+						title = "Original file behavior:",
+						alignment = 'right',
+						width = LrView.share "label_width",
+					},
+					f:popup_menu {
+						alignment = 'left',
+						immediate = true,
+						width_in_chars = 35,
+						items = {
+							{ title = "Don't upload original files", value = 'none' },
+							{ title = "Upload originals for edited photos only", value = 'edited' },
+							{ title = "Upload originals for all photos (non recommended)", value = 'all' },
+						},
+						value = bind 'originalFileMode',
+						tooltip = "Note : Due to Lightroom limitations, edited photos means at leastone core parameter has been adjusted (exposure, contrast, highlights, shadows, whites, blacks, texture, clarity, vibrance, saturation, crop).",
+					},
+				},
+			},
+		},
+
+		{
 			title = "Immich Server connection",
 			bind_to_object = propertyTable,
 

--- a/immich-plugin.lrplugin/ExportDialogSections.lua
+++ b/immich-plugin.lrplugin/ExportDialogSections.lua
@@ -63,10 +63,10 @@ function ExportDialogSections.sectionsForBottomOfDialog(f, propertyTable)
 						items = {
 							{ title = "Don't upload original files", value = 'none' },
 							{ title = "Upload originals for edited photos only", value = 'edited' },
-							{ title = "Upload originals for all photos (non recommended)", value = 'all' },
+							{ title = "Upload originals for all photos", value = 'all' },
 						},
 						value = bind 'originalFileMode',
-						tooltip = "Note : Due to Lightroom limitations, edited photos means at leastone core parameter has been adjusted (exposure, contrast, highlights, shadows, whites, blacks, texture, clarity, vibrance, saturation, crop).",
+						tooltip = "Note: Due to Lightroom limitations, edited photos means at least one core parameter has been adjusted (exposure, contrast, highlights, shadows, whites, blacks, texture, clarity, vibrance, saturation, crop, local adjustments, or virtual copies).",
 					},
 				},
 			},

--- a/immich-plugin.lrplugin/ExportDialogSections.lua
+++ b/immich-plugin.lrplugin/ExportDialogSections.lua
@@ -1,7 +1,10 @@
 require "ImmichAPI"
+require "StackManager"
+
+local LrTasks = import 'LrTasks'
+local LrColor = import 'LrColor'
 
 ExportDialogSections = {}
-
 
 local function _updateCantExportBecause(propertyTable)
 	LrTasks.startAsyncTask(function()
@@ -17,9 +20,24 @@ local function _updateCantExportBecause(propertyTable)
 	end)
 end
 
+local function _updateEditedPhotosCount(propertyTable)
+	-- Only run if the mode is set to 'edited'
+	if propertyTable.originalFileMode ~= 'edited' then
+		propertyTable.editedPhotosCount = ""
+		return
+	end
+	
+	LrTasks.startAsyncTask(function()
+		local analysis = StackManager.analyzeSelectedPhotos()
+		propertyTable.editedPhotosCount = analysis.summary
+	end)
+end
+
 -------------------------------------------------------------------------------
 
 function ExportDialogSections.startDialog(propertyTable)
+	-- Initialize edited photos count
+	propertyTable.editedPhotosCount = ""
 
 	LrTasks.startAsyncTask(function()
 		propertyTable.immich = ImmichAPI:new(propertyTable.url, propertyTable.apiKey)
@@ -29,6 +47,19 @@ function ExportDialogSections.startDialog(propertyTable)
 	-- propertyTable:addObserver('url', _updateCantExportBecause)
 	-- propertyTable:addObserver('apiKey', _updateCantExportBecause)
 	
+	-- Add observer for originalFileMode changes
+	propertyTable:addObserver('originalFileMode', function(key, value)
+		_updateEditedPhotosCount(propertyTable)
+	end)
+	
+	-- Trigger initial count if mode is already set to 'edited'
+	if propertyTable.originalFileMode == 'edited' then
+		-- Small delay to ensure UI is ready
+		LrTasks.startAsyncTask(function()
+			LrTasks.sleep(0.1)
+			_updateEditedPhotosCount(propertyTable)
+		end)
+	end
 end
 
 -------------------------------------------------------------------------------
@@ -72,8 +103,21 @@ function ExportDialogSections.sectionsForBottomOfDialog(f, propertyTable)
 							{ title = "Upload originals for edited photos only", value = 'edited' },
 							{ title = "Upload originals for all photos", value = 'all' },
 						},
-						value = bind 'originalFileMode',
-						tooltip = "Note: Due to Lightroom limitations, edited photos means at least one core parameter has been adjusted (exposure, contrast, highlights, shadows, whites, blacks, texture, clarity, vibrance, saturation, crop, local adjustments, or virtual copies).",
+						value = bind 'originalFileMode'
+					},
+				},
+				f:row {
+					f:static_text {
+						title = "",
+						alignment = 'right',
+						width = LrView.share "label_width",
+					},
+					f:static_text {
+						title = bind 'editedPhotosCount',
+						alignment = 'left',
+						fill_horizontal = 1,
+						font = '<system/small>',
+						text_color = LrColor(0.2, 0.6, 0.2),
 					},
 				},
 			},
@@ -142,7 +186,6 @@ end
 
 -------------------------------------------------------------------------------
 
-
 function ExportDialogSections.sectionsForTopOfDialog(_, propertyTable)
 	local f = LrView.osFactory()
 	local bind = LrView.bind
@@ -190,8 +233,8 @@ function ExportDialogSections.sectionsForTopOfDialog(_, propertyTable)
 							width_in_chars = 20,
 							fill_horizontal = 1,
 							value = bind 'newAlbumName',
-							visible = LrBinding.keyEquals("albumMode", "new"),
 							align = "left",
+							visible = LrBinding.keyEquals("albumMode", "new"),
 						},
 					},
 				},

--- a/immich-plugin.lrplugin/ExportDialogSections.lua
+++ b/immich-plugin.lrplugin/ExportDialogSections.lua
@@ -46,6 +46,13 @@ function ExportDialogSections.sectionsForBottomOfDialog(f, propertyTable)
 					f:static_text {
 						title = "Upload original files alongside edited exports to create stacks in Immich.",
 						alignment = 'left',
+						font = '<system/small>',
+					},
+				},
+				f:row {
+					f:static_text {
+						title = "Tip: Uploading originals increases file size but preserves RAW data for future edits.",
+						alignment = 'left',
 						text_color = LrColor( 0.6, 0.6, 0.6 ),
 						font = '<system/small>',
 					},

--- a/immich-plugin.lrplugin/ExportDialogSections.lua
+++ b/immich-plugin.lrplugin/ExportDialogSections.lua
@@ -21,16 +21,26 @@ local function _updateCantExportBecause(propertyTable)
 end
 
 local function _updateEditedPhotosCount(propertyTable)
-	-- Only run if the mode is set to 'edited'
-	if propertyTable.originalFileMode ~= 'edited' then
-		propertyTable.editedPhotosCount = ""
-		return
-	end
-	
-	LrTasks.startAsyncTask(function()
-		local analysis = StackManager.analyzeSelectedPhotos()
-		propertyTable.editedPhotosCount = analysis.summary
-	end)
+    if propertyTable.originalFileMode ~= 'edited' then
+        propertyTable.editedPhotosCount = ""
+        return
+    end
+    
+    -- Show immediate feedback for all selections
+    local catalog = LrApplication.activeCatalog()
+    if catalog then
+        local selectedPhotos = catalog:getTargetPhotos()
+        if selectedPhotos and #selectedPhotos > 0 then
+            propertyTable.editedPhotosCount = "Analyzing " .. #selectedPhotos .. " photos..."
+        else
+            propertyTable.editedPhotosCount = "Analyzing photos..."
+        end
+    end
+    
+    LrTasks.startAsyncTask(function()
+        local analysis = StackManager.analyzeSelectedPhotos()
+        propertyTable.editedPhotosCount = analysis.summary
+    end)
 end
 
 -------------------------------------------------------------------------------

--- a/immich-plugin.lrplugin/ExportServiceProvider.lua
+++ b/immich-plugin.lrplugin/ExportServiceProvider.lua
@@ -14,6 +14,7 @@ return {
 		{ key = "apiKey", default = '' },
 		{ key = 'album',     default = nil },
 		{ key = 'albumMode', default = nil },
+		{ key = 'originalFileMode', default = 'none' },
 	},
 
 	canExportVideo = true,

--- a/immich-plugin.lrplugin/ExportTask.lua
+++ b/immich-plugin.lrplugin/ExportTask.lua
@@ -1,5 +1,6 @@
 require "ImmichAPI"
 require "MetadataTask"
+require "StackManager"
 
 --============================================================================--
 
@@ -21,10 +22,31 @@ function ExportTask.processRenderedPhotos(functionContext, exportContext)
 
     -- Set progress title.
     local nPhotos = exportSession:countRenditions()
+    
+    local progressTitle
+    if exportParams.originalFileMode and exportParams.originalFileMode ~= 'none' then
+        local modeText = ""
+        if exportParams.originalFileMode == 'edited' then
+            modeText = " (with originals for edited)"
+        elseif exportParams.originalFileMode == 'all' then
+            modeText = " (with originals for all)"
+        end
+        
+        if nPhotos > 1 then
+            progressTitle = "Exporting " .. nPhotos .. " photos" .. modeText .. " to " .. exportParams.url
+        else
+            progressTitle = "Exporting one photo" .. modeText .. " to " .. exportParams.url
+        end
+    else
+        if nPhotos > 1 then
+            progressTitle = "Exporting " .. nPhotos .. " photos to " .. exportParams.url
+        else
+            progressTitle = "Exporting one photo to " .. exportParams.url
+        end
+    end
+    
     local progressScope = exportContext:configureProgress {
-        title = nPhotos > 1
-            and "Exporting " .. nPhotos .. " photos to " .. prefs.url
-            or "Exporting one photo to " .. prefs.url
+        title = progressTitle
     }
 
     -- local immich = ImmichAPI:new(prefs.url, prefs.apiKey)
@@ -141,6 +163,7 @@ function ExportTask.processRenderedPhotos(functionContext, exportContext)
 
     -- Iterate through photo renditions.
     local failures = {}
+    local stackWarnings = {}
     local atLeastSomeSuccess = false
 
     for _, rendition in exportContext:renditions { stopIfCanceled = true } do
@@ -166,6 +189,26 @@ function ExportTask.processRenderedPhotos(functionContext, exportContext)
                 table.insert(failures, pathOrMessage)
             else
                 atLeastSomeSuccess = true
+                
+                -- Handle original file stacking if enabled
+                if exportParams.originalFileMode and exportParams.originalFileMode ~= 'none' then
+                    local shouldStack = false
+                    
+                    if exportParams.originalFileMode == 'all' then
+                        shouldStack = true
+                    elseif exportParams.originalFileMode == 'edited' then
+                        shouldStack = StackManager.hasEdits(rendition.photo)
+                    end
+                    
+                    if shouldStack then
+                        local finalId, stackError = StackManager.processPhotoWithStack(immich, rendition, id, exportParams)
+                        if stackError then
+                            table.insert(stackWarnings, rendition.photo:getFormattedMetadata("fileName") .. ": " .. stackError)
+                            log:warn("Stack processing warning: " .. stackError)
+                        end
+                    end
+                end
+                
                 -- MetadataTask.setImmichAssetId(rendition.photo, id)
                 if useAlbum then
                     log:trace('Adding asset to album')
@@ -190,7 +233,7 @@ function ExportTask.processRenderedPhotos(functionContext, exportContext)
         immich:deleteAlbum(albumId)
     end
 
-    -- Report failures.
+    -- Report failures and warnings.
     if #failures > 0 then
         local message
         if #failures == 1 then
@@ -199,5 +242,16 @@ function ExportTask.processRenderedPhotos(functionContext, exportContext)
             message = tostring(#failures) .. " files failed to upload correctly."
         end
         LrDialogs.message(message, table.concat(failures, "\n"))
+    end
+    
+    -- Report stack warnings separately
+    if #stackWarnings > 0 then
+        local message
+        if #stackWarnings == 1 then
+            message = "1 photo had stacking issues (uploaded without stack):"
+        else
+            message = tostring(#stackWarnings) .. " photos had stacking issues (uploaded without stacks):"
+        end
+        LrDialogs.message(message, table.concat(stackWarnings, "\n"))
     end
 end

--- a/immich-plugin.lrplugin/ImmichAPI.lua
+++ b/immich-plugin.lrplugin/ImmichAPI.lua
@@ -398,6 +398,27 @@ function ImmichAPI:addAssetToAlbum(albumId, assetId)
     return true
 end
 
+function ImmichAPI:createStack(assetIds)
+    if not assetIds or #assetIds < 2 then
+        util.handleError('createStack: need at least 2 assets', 'Need at least 2 assets to create a stack. Check logs.')
+        return nil
+    end
+
+    local apiPath = '/stacks'
+    local postBody = { assetIds = assetIds }
+
+    log:trace('Creating stack with assets: ' .. JSON:encode(assetIds))
+    
+    local parsedResponse = ImmichAPI.doPostRequest(self, apiPath, postBody)
+    if parsedResponse ~= nil then
+        log:trace('Stack created successfully with ID: ' .. parsedResponse.id)
+        return parsedResponse.id
+    else
+        log:error('Failed to create stack')
+        return nil
+    end
+end
+
 function ImmichAPI:createAlbum(albumName)
     if util.nilOrEmpty(albumName) then
         util.handleError('createAlbum: albumName empty', 'No album name given. Check logs.')

--- a/immich-plugin.lrplugin/StackManager.lua
+++ b/immich-plugin.lrplugin/StackManager.lua
@@ -1,0 +1,127 @@
+--[[
+StackManager.lua - Handles photo stacking functionality for Immich plugin
+
+This module provides functionality to:
+1. Detect if a photo has been edited in Lightroom
+2. Upload original files alongside edited exports
+3. Create stacks in Immich with edited photo as primary
+
+Author: Immich Plugin Contributors
+--]]
+
+local LrPathUtils = import 'LrPathUtils'
+local LrFileUtils = import 'LrFileUtils'
+local LrLogger = import 'LrLogger'
+
+require "ImmichAPI"
+
+-- Initialize logging
+local log = LrLogger('ImmichPlugin')
+log:enable("logfile")
+
+StackManager = {}
+
+--------------------------------------------------------------------------------
+-- Check if a photo has been edited in Lightroom
+-- Analyzes core develop settings that indicate user adjustments
+function StackManager.hasEdits(photo, editedPhotosCache)
+    -- Check develop settings for core editing parameters
+    local developSettings = photo:getDevelopSettings()
+    if not developSettings then
+        return false
+    end
+    
+    -- Check core editing parameters that indicate user adjustments
+    local coreParams = {
+        "Exposure2012", "Contrast2012", "Highlights2012", "Shadows2012", 
+        "Whites2012", "Blacks2012", "Texture", "Clarity2012", 
+        "Vibrance", "Saturation"
+    }
+    
+    for _, param in ipairs(coreParams) do
+        local value = developSettings[param]
+        if value and math.abs(value) > 0.001 then
+            return true
+        end
+    end
+    
+    -- Check for cropping
+    if developSettings.HasCrop then
+        return true
+    end
+    
+    -- Check for local adjustments (masks/brushes)
+    if developSettings.MaskGroupBasedCorrections and #developSettings.MaskGroupBasedCorrections > 0 then
+        return true
+    end
+    
+    return false
+end
+
+--------------------------------------------------------------------------------
+-- Get the original file path for a photo
+function StackManager.getOriginalFilePath(photo)
+    local originalPath = photo:getRawMetadata("path")
+    
+    if originalPath and LrFileUtils.exists(originalPath) then
+        return originalPath
+    end
+    
+    log:warn("Original file not found or inaccessible: " .. tostring(originalPath))
+    return nil
+end
+
+--------------------------------------------------------------------------------
+-- Generate device asset ID for original file
+-- Appends "_original" to the base photo ID to ensure uniqueness
+function StackManager.generateOriginalDeviceAssetId(baseId, originalPath)
+    return tostring(baseId) .. "_original"
+end
+
+--------------------------------------------------------------------------------
+-- Upload original file and create stack with edited photo as primary
+function StackManager.processPhotoWithStack(immich, rendition, editedAssetId, exportParams)
+    local photo = rendition.photo
+    
+    -- Get original file path
+    local originalPath = StackManager.getOriginalFilePath(photo)
+    if not originalPath then
+        log:warn("Cannot access original file for: " .. photo.localIdentifier)
+        return editedAssetId, "Cannot access original file"
+    end
+    
+    -- Generate device asset ID for original
+    local originalDeviceAssetId = StackManager.generateOriginalDeviceAssetId(
+        photo.localIdentifier, originalPath)
+    
+    log:trace("Uploading original file: " .. originalPath)
+    
+    -- Check if original asset already exists
+    local existingOriginalId = immich:checkIfAssetExists(originalDeviceAssetId,
+        LrPathUtils.leafName(originalPath), photo:getFormattedMetadata("dateCreated"))
+    
+    local originalAssetId
+    if existingOriginalId then
+        originalAssetId = existingOriginalId
+        log:trace("Original asset already exists: " .. originalAssetId)
+    else
+        -- Upload original file
+        originalAssetId = immich:uploadAsset(originalPath, originalDeviceAssetId)
+    end
+    
+    if not originalAssetId then
+        return editedAssetId, "Failed to upload original file"
+    end
+    
+    -- Create stack with edited as primary, original as secondary
+    local stackId = immich:createStack({editedAssetId, originalAssetId})
+    
+    if stackId then
+        log:trace("Stack created successfully: " .. stackId)
+        return editedAssetId, nil -- Success
+    else
+        return editedAssetId, "Failed to create stack"
+    end
+end
+
+return StackManager

--- a/immich-plugin.lrplugin/StackManager.lua
+++ b/immich-plugin.lrplugin/StackManager.lua
@@ -6,7 +6,6 @@ This module provides functionality to:
 2. Upload original files alongside edited exports
 3. Create stacks in Immich with edited photo as primary
 
-Author: Immich Plugin Contributors
 --]]
 
 local LrPathUtils = import 'LrPathUtils'
@@ -52,6 +51,12 @@ function StackManager.hasEdits(photo, editedPhotosCache)
     
     -- Check for local adjustments (masks/brushes)
     if developSettings.MaskGroupBasedCorrections and #developSettings.MaskGroupBasedCorrections > 0 then
+        return true
+    end
+    
+    -- Check for virtual copies (copies virtuelles) - external edits like Photoshop
+    local copyName = photo:getFormattedMetadata("copyName")
+    if copyName and copyName ~= "" then
         return true
     end
     


### PR DESCRIPTION
Hi !

Firstly, thanks a LOT for your amazing project ! I'm using it now daily with my little camera, and it's been a way for me to force me to take care of my pictures and memories ❤️

For me, something has been missing from this plugin : I import my pictures into Lightroom, do some triage, and slight retouching.

**But what if I don't like the edits I've done in the future?** Should I keep my whole Lightroom catalog and original files on my computer, even though I have a copy on Immich ?

So I imagined and developed this feature, that allows you to keep the original file when you upload to Immich through the plugin. To be organized, the original file is put as "Immich Stacks". Your exported file shows as the main media, but you have the possibility to see and download later the file that was on camera, untouched by Lightroom. I think it's a great feature for posterity !

This is what it looks like in the end.
 
 
 
### New menu in export dialog.

![Kapture 2025-08-25 at 11 58 22](https://github.com/user-attachments/assets/76e946f3-f3d5-4836-99b8-914e4af21715)

3 options to choose from.

- Don't upload your original to Immich (don't use the feature)
- Upload original files as Immich Stacks only for images on which an edit was detected by the plugin _(see below)_
- Upload all original files as Immich Stacks



### What it looks in the end.

![Kapture 2025-08-25 at 11 54 43](https://github.com/user-attachments/assets/9891985e-00a2-4e17-a0c5-724cbbc885b3)

Your original files are put into stack on top of your exported version.

### About the "edited" photo detection.

It was important for me to have the possibility to upload original files only when a Lightroom develop option was changed. Because it happened to me when I was using the plugin to send unedited photos to Immich, so I could edit the exported version later if I wanted to with a reduced file size. But I came across Lightroom SDK limitation.

Adobe is supposed to expose a hasAdjustement Metadata, but I did not manage to get it working on my Lightroom version.

I tried to use others variables like photo:getDevelopSettings(), but it turns out that for many settings, the defaults are different and sometimes automaticly tweaked for RAW images. So it requires a list of all Lightroom defaults values, which is not very clean. I also cannot manage to access the Develop history of the Develop panel to see if there were some edits.

To make this work, I choose to define an "edited image" if there is at least one of these values changed : exposure, contrast, highlights, shadows, whites, blacks, texture, clarity, vibrancy, saturation, cropping, masks/brushes, or if it is a virtual copy.
It was the easiest to not add a lot of boilerplate code, and I feel like in a real world scenario, at least one of these parameters are touched to retouch a picture. There is a tooltip on the option to explain this.


I hope this feature can be merged into the base project and that it will be useful. Please feel free to contact me if you think any changes are necessary.