### PR TITLE
Import config improvements: dialog size, custom path

### DIFF
--- a/immich-plugin.lrplugin/ImportServiceProvider.lua
+++ b/immich-plugin.lrplugin/ImportServiceProvider.lua
@@ -181,7 +181,7 @@ local function showConfigurationDialog()
                 truncation = 'middle',
                 immediate = false,
                 fill_horizontal = 1,
-                width_in_chars = 35,
+                width_in_chars = 28,
                 validate = function (v, url)
                     local sanitizedURL = ImmichAPI:sanityCheckAndFixURL(url)
                     if sanitizedURL == url then
@@ -220,7 +220,7 @@ local function showConfigurationDialog()
                 truncation = 'middle',
                 immediate = true,
                 fill_horizontal = 1,
-                width_in_chars = 35,
+                width_in_chars = 28,
             },
         },
 
@@ -235,7 +235,7 @@ local function showConfigurationDialog()
                 truncation = 'middle',
                 immediate = false,
                 fill_horizontal = 1,
-                width_in_chars = 35,
+                width_in_chars = 28,
                 validate = function (v, path)
                     if path and path ~= "" then
                         if LrFileUtils.exists(path) then

--- a/immich-plugin.lrplugin/ImportServiceProvider.lua
+++ b/immich-plugin.lrplugin/ImportServiceProvider.lua
@@ -174,7 +174,7 @@ local function showConfigurationDialog()
             f:static_text {
                 title = "URL:",
                 alignment = 'right',
-                width = LrView.share 'immich_label_width'
+                width = share 'labelWidth'
             },
             f:edit_field {
                 value = bind 'url',
@@ -212,7 +212,7 @@ local function showConfigurationDialog()
             f:static_text {
                 title = "API Key:",
                 alignment = 'right',
-                width = LrView.share 'immich_label_width',
+                width = share 'labelWidth',
                 visible = bind 'hasNoError',
             },
             f:password_field {
@@ -228,7 +228,7 @@ local function showConfigurationDialog()
             f:static_text {
                 title = "Import Path:",
                 alignment = 'right',
-                width = LrView.share 'immich_label_width',
+                width = share 'labelWidth',
             },
             f:edit_field {
                 value = bind 'importPath',

--- a/immich-plugin.lrplugin/Init.lua
+++ b/immich-plugin.lrplugin/Init.lua
@@ -36,3 +36,4 @@ end
 
 if _G.prefs.apiKey == nil then _G.prefs.apiKey = '' end
 if _G.prefs.url == nil then _G.prefs.url = '' end
+if _G.prefs.importPath == nil then _G.prefs.importPath = LrPathUtils.child(LrPathUtils.getStandardFilePath("pictures"), "Immich Import") end


### PR DESCRIPTION
Hi -
Thanks for the great project!

I tested the import functionality yesterday and ran into two issues that I've fixed in this PR.

- joey

## Unreadable import config window.

Original:
<img width="457" height="323" alt="image" src="https://github.com/user-attachments/assets/6f940a94-cb8d-44bb-81dc-172595cb58d8" />

Updated:
<img width="1122" height="391" alt="image" src="https://github.com/user-attachments/assets/e343b452-be5d-4000-a32e-da56e1a8f5bd" />

References that I used:
- [Lightroom SDK Examples](https://github.com/Jaid/lightroom-sdk-8-examples/blob/main/helloworld.lrdevplugin/CustomDialogWithObserver.lua)
- [Rob Allen Example](https://akrabat.com/creating-collections-with-the-lightroom-classic-sdk/)

## Import path

My Lightroom library is on a separate drive, so I could see the imports happening but couldn't see the photos. I eventually found them in my user directory. So this second change generalizes the setup.

Original:
- hardcoded to ~/Pictures/Immich Import

Updated:
- defaults to ~/Pictures/Immich Import but user can override in the import dialog
- the path is validated and logged etc after the user specifies it.

## Validation

My setup = Lightroom 14.5.1 on Windows -> Immich 1.140.1 on Unraid

Checks:
- verified import to existing folders, in home folder (current default) and custom folder
- verified that invalid folder is detected and a warning dialog pops up
- verified that results are logged correctly