### PR TITLE
fixes the `original_plus_jpeg_if_edited` export mode (issue #91) +

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.claude

--- a/PR.md
+++ b/PR.md
@@ -1,8 +1,8 @@
-# Pull Request: Fix original+export stacking, UI clarity, and reliability bugs
+# Pull Request: Fix original+export stacking, UI clarity, reliability bugs, and upload resiliency
 
 ## Summary
 
-This PR fixes the `original_plus_jpeg_if_edited` export mode (issue #91), corrects several bugs that caused duplicate uploads and wrong stack ordering, improves UI labeling, and addresses memory and timeout issues that caused failures on large exports.
+This PR fixes the `original_plus_jpeg_if_edited` export mode (issue #91), corrects several bugs that caused duplicate uploads and wrong stack ordering, improves UI labeling, addresses memory and timeout issues that caused failures on large exports, and replaces the batch-collect upload path with a per-photo-pair streaming accumulator to eliminate temp-disk exhaustion on large exports. All DNG/JPG-specific naming and file-type hardcoding has been replaced with format-agnostic equivalents so the stacking feature works correctly for any original+export pairing (DNG+JPG, CR2+TIF, TIF+JPG, etc.).
 
 ---
 
@@ -10,17 +10,17 @@ This PR fixes the `original_plus_jpeg_if_edited` export mode (issue #91), correc
 
 ### 1. Stack primary image was wrong (ExportTask.lua)
 
-**Problem:** `createStack({ id, jpegId })` was called with the original file first. Immich uses the first element as the stack's key/cover image, so the unedited original was shown as the primary instead of the edited export.
+**Problem:** `createStack({ id, exportId })` was called with the original file first. Immich uses the first element as the stack's key/cover image, so the unedited original was shown as the primary instead of the edited export.
 
-**Fix:** Swapped to `createStack({ jpegId, id })` so the rendered export is the primary in both `processOnePhotoGroup` and `processSingleRenditionRenditions`.
+**Fix:** Swapped to `createStack({ exportId, id })` so the rendered export is the primary in both `processOnePhotoGroup` and `processSingleRenditionRenditions`.
 
 ---
 
 ### 2. Album received the wrong asset (ExportTask.lua)
 
-**Problem:** After creating a stack, both code paths added the original (`id`) to the album and recorded it as the primary, even when the edited export (`jpegId`) was available.
+**Problem:** After creating a stack, both code paths added the original (`id`) to the album and recorded it as the primary, even when the edited export was available.
 
-**Fix:** Introduced a `primaryId` variable that defaults to `id` and is updated to `jpegId` when the export upload succeeds. Album assignment and `exportedPrimaryByPhoto` now use `primaryId`.
+**Fix:** Introduced a `primaryId` variable that defaults to `id` and is updated to `exportId` when the export upload succeeds. Album assignment and `exportedPrimaryByPhoto` now use `primaryId`.
 
 ---
 
@@ -71,64 +71,77 @@ This PR fixes the `original_plus_jpeg_if_edited` export mode (issue #91), correc
 
 **Problem:** When an `editedPhotosCache` was provided but the photo was not in it (meaning no edits), the function fell through to a fallback that ran two full `catalog:findPhotos` queries anyway — the same queries that were used to build the cache. For large catalogs this meant two extra full-catalog scans per unedited photo.
 
-**Fix:** When a cache is present it is now used exclusively. A cache miss immediately returns `false` without any fallback queries.
+**Fix:** When a cache is present it is now used exclusively. A cache miss immediately returns `false` without any fallback queries. Function comment updated to accurately describe this behaviour.
 
 ---
 
-## UI improvements (ExportDialogSections.lua)
+### 9. Inline accumulator replaces batch-collect in original+export flow (ExportTask.lua, PublishTask.lua)
 
-- **Dropdown labels updated** to be format-agnostic:
-  - `"Always upload original only (no JPG)"` → `"Always upload original only (no export)"`
-  - `"Always upload original, JPG only if edited"` → `"Always upload original + rendered export (if edited)"`
-- **Section label** `"original+export export:"` → `"Original + Export:"` and checkbox `"Stack in Immich (edited JPG as primary)"` → `"Stack in Immich (export as primary)"` — the feature works with any export format, not just JPEG.
-- **Warning message** displayed in orange when "Original / no reformat" export format is selected alongside the "upload original + rendered export" mode, prompting the user to switch to JPEG or TIFF.
+**Problem:** `processStackOriginalExportRenditions` (and its publish counterpart) called `UploadHelpers.collectRenditions`, which waited for every rendition across the entire export batch to finish rendering before the first upload began. On large exports this caused all temp files to accumulate on disk simultaneously, risking temp-disk exhaustion and delaying any upload feedback.
+
+**Fix:** Replaced `collectRenditions` + `groupByPhoto` with an inline accumulator loop in both `processStackOriginalExportRenditions` (ExportTask.lua) and `processPublishStackOriginalExportRenditions` (PublishTask.lua). Each photo group is flushed — uploaded, stacked, temp files deleted — as soon as both of its renditions have arrived. Groups where one rendition failed to render are flushed as a single-item group at the end of the loop. `UploadHelpers.collectRenditions` and `groupByPhoto` are retained for other callers.
+
+Edge cases handled:
+
+- Render failure on one of a pair → single-item flush at end; `processOnePhotoGroup` already handles the 1-item case.
+- Cancellation mid-export → already-flushed groups have temp files deleted; in-progress accumulator items remain (same as single-rendition path).
+- Interleaved renditions from different photos → accumulator correctly groups by `localIdentifier` regardless of render order.
 
 ---
 
-## Known limitations / not in this PR
+### 10. Missing warning when rendered export upload fails (ExportTask.lua)
 
-### collectRenditions batches all renders before upload starts (UploadHelpers.lua)
+**Problem:** In `processOnePhotoGroup`, when the `original_plus_jpeg_if_edited` mode uploaded the original successfully but the rendered export upload returned nil, the failure was silent — no entry was added to `stackWarnings`. The equivalent path in `processSingleRenditionRenditions` did emit a warning.
 
-For the original+export stacking path, `collectRenditions` waits for all renditions across the entire export batch to finish rendering before the first upload begins. On large exports this can fill temp disk before any files are cleaned up. The single-rendition path does not have this issue — it pipes render → upload → delete per photo.
+**Fix:** Added an `else` branch to append `"failed to upload rendered export"` to `stackWarnings` when `exportId` is nil, matching the behaviour of the single-rendition path.
 
-This was not fixed in this PR due to the scope of the required restructuring. Monitor temp disk usage during large original+export exports.
+---
 
-#### Plan for future fix
+## Format-agnostic cleanup
 
-Replace `collectRenditions` in `processStackDngJpgRenditions` (ExportTask.lua) and `processPublishStackDngJpgRenditions` (PublishTask.lua) with an inline accumulator loop that flushes each photo group as soon as it is complete:
+The original+export stacking feature was implemented with DNG+JPG as the only use case in mind. All format-specific naming and file-type logic has been removed so the feature works correctly for any pairing (DNG+JPG, CR2+TIF, original JPG+export JPG, etc.).
 
-```lua
-local accumulator = {}  -- lid -> { items }
-for _, rendition in exportContext:renditions { stopIfCanceled = true } do
-    if progressScope:isCanceled() then break end
-    local success, pathOrMessage = rendition:waitForRender()
-    if progressScope:isCanceled() then break end
-    if success then
-        local lid = rendition.photo.localIdentifier
-        if not accumulator[lid] then accumulator[lid] = {} end
-        table.insert(accumulator[lid], {
-            path = pathOrMessage,
-            photo = rendition.photo,
-            rendition = rendition,
-            ext = util.getExtension(pathOrMessage),
-            fileType = StackManager.getFileType(pathOrMessage),
-        })
-        -- Two renditions = group complete: upload and delete immediately
-        if #accumulator[lid] == 2 then
-            processOnePhotoGroup(immich, lid, accumulator[lid], ...)
-            accumulator[lid] = nil
-        end
-    end
-end
--- Flush any remaining single-rendition groups (e.g. one rendition failed to render)
-for lid, items in pairs(accumulator) do
-    processOnePhotoGroup(immich, lid, items, ...)
-end
-```
+### Renamed identifiers
 
-`processOnePhotoGroup` already handles the 1-item case so the end-of-loop flush requires no changes there. `UploadHelpers.collectRenditions` and `groupByPhoto` are no longer called from these paths but can remain for other uses.
+| Before | After | Files |
+| ------ | ----- | ----- |
+| `stackDngJpg` (preference key + bindings) | `stackOriginalExport` | ExportServiceProvider.lua, PublishServiceProvider.lua, ExportDialogSections.lua, PublishDialogSections.lua, ExportTask.lua, PublishTask.lua |
+| `processStackDngJpgRenditions` | `processStackOriginalExportRenditions` | ExportTask.lua |
+| `processPublishStackDngJpgRenditions` | `processPublishStackOriginalExportRenditions` | PublishTask.lua |
+| `sortDngJpgItems` | `sortOriginalExportItems` | UploadHelpers.lua |
+| `jpegId` | `exportId` | ExportTask.lua |
+| `existingJpegId` | `existingExportId` | ExportTask.lua |
+| `existingJpegDeviceId` | `existingExportDeviceId` | ExportTask.lua |
 
-**Edge cases to test:** render failure on one of a pair (group flushes as single-item at end), cancellation mid-export (temp files from flushed groups are already deleted, only in-progress accumulator items remain), and interleaved renditions from different photos (accumulator handles this correctly regardless of order).
+### Sort logic made format-agnostic (UploadHelpers.lua)
+
+**Before:** `sortDngJpgItems` sorted by file type (`jpeg=1`, `raw=2`, `other=3`). For pairings where the export is not a JPEG (e.g., DNG+TIF), the sort placed the original first, making it the Immich stack primary — the opposite of the intended behaviour.
+
+**After:** `sortOriginalExportItems` identifies the original by comparing `item.path` to `StackManager.getOriginalFilePath(item.photo)`. The export (non-original) always sorts first regardless of format.
+
+### File-type checks removed (ExportTask.lua, PublishTask.lua)
+
+**Before:** `processOnePhotoGroup` / `processPublishOnePhotoGroup` computed `hasRaw` and `hasJpeg` from each item's file type and only stacked when both were present (`shouldStackDngJpg = hasRaw and hasJpeg`). Any pairing that wasn't exactly raw+jpeg would skip stacking silently.
+
+**After:** `#items >= 2` is the only condition for stacking. Any two renditions for the same photo in `stackOriginalExport` mode are treated as an original+export pair.
+
+### Dead code removed (StackManager.lua, UploadHelpers.lua, ExportTask.lua, PublishTask.lua)
+
+- `StackManager.getFileType` and `RAW_EXT` removed — no longer called.
+- `fileType` field removed from item tables in all three accumulators — was populated but never read after the file-type checks were removed.
+
+---
+
+## UI improvements
+
+- **ExportDialogSections.lua:** Dropdown labels updated to be format-agnostic; "Original / no reformat" warning added (orange text).
+- **PublishDialogSections.lua:** Stack section label `"DNG+JPG:"` → `"Original + Export:"`, checkbox `"Stack in Immich (edited JPG as primary)"` → `"Stack in Immich (export as primary)"`.
+
+> **Note:** The `stackDngJpg` preference key has been renamed to `stackOriginalExport`. Users with existing export presets or publish collections that had the stacking checkbox enabled will need to re-enable it after updating.
+
+---
+
+## Known limitations
 
 ### Upload timeout is configurable by editing ImmichAPI.lua
 
@@ -136,7 +149,7 @@ end
 
 ### Stack warnings in the post-export dialog
 
-If any individual upload or stack creation fails, it is reported as a warning after export completes rather than aborting the entire run. Check the post-export dialog and the log file (`ImmichPlugin.log`) for `"failed to upload"` or `"failed to create stack"` entries.
+If any individual upload or stack creation fails, it is reported as a warning after export completes rather than aborting the entire run. Check the post-export dialog and the log file (`ImmichPlugin.log`) for `"failed to upload"` or `"failed to create stack"` entries. Re-exporting is self-healing: duplicate detection finds previously uploaded assets, missing companions are uploaded fresh, and stacks are created once both IDs are available.
 
 ---
 
@@ -144,8 +157,12 @@ If any individual upload or stack creation fails, it is reported as a warning af
 
 | File | Changes |
 |------|---------|
-| `ExportTask.lua` | Stack order fix, album primary fix, LR_format guard (×2), `checkIfAssetExistsEnhanced`, extension-based deviceAssetId |
-| `ExportDialogSections.lua` | Warning UI, updated dropdown labels, section label rename |
+| `ExportTask.lua` | Stack order fix, album primary fix, LR_format guard (×2), `checkIfAssetExistsEnhanced`, extension-based deviceAssetId, inline accumulator, missing export-upload warning, format-agnostic renames |
+| `PublishTask.lua` | Extension-based deviceAssetId, inline accumulator, format-agnostic renames |
+| `ExportDialogSections.lua` | Warning UI, updated dropdown labels, section label rename, `stackOriginalExport` bind |
+| `PublishDialogSections.lua` | Section label and checkbox text updated, `stackOriginalExport` bind |
+| `ExportServiceProvider.lua` | `stackOriginalExport` preference key |
+| `PublishServiceProvider.lua` | `stackOriginalExport` preference key |
 | `ImmichAPI.lua` | Timeout increases, `table.concat` multipart body, explicit POST timeout |
-| `StackManager.lua` | `hasEdits` cache short-circuit |
-| `PublishTask.lua` | Extension-based deviceAssetId for original+export stacking |
+| `StackManager.lua` | `hasEdits` cache short-circuit and comment fix, removed `getFileType` / `RAW_EXT` |
+| `UploadHelpers.lua` | `sortOriginalExportItems` with path-based sort, removed `fileType` field, updated comment |

--- a/PR.md
+++ b/PR.md
@@ -41,7 +41,7 @@ This PR fixes the `original_plus_jpeg_if_edited` export mode (issue #91), correc
 
 **Fix:** Each item receives an `isOriginal` flag at accumulation time (true if the rendered file's extension matches the source file's extension, indicating an original-format copy) and an `insertionOrder` counter (0-based, evaluated before the item is inserted into the accumulator). `sortOriginalExportItems` sorts items so the export (`isOriginal == false`) comes first; when both items have the same `isOriginal` value, `insertionOrder` is used as a stable tiebreaker. Index-based suffixes are then assigned after the sort: `_export` for `items[1]` (primary in Immich), `_orig` for `items[2]`. IDs are stable regardless of rendering failures and distinct regardless of file format pairing.
 
-**JPEG→JPEG edge case:** When source and export share the same extension, both items have `isOriginal=true`. Sort falls back to `insertionOrder`, so the rendition Lightroom produced first (typically the original copy) becomes `items[1]` and receives the `_export` label; the edited export receives `_orig`. Role labels are semantically inverted for same-extension pairs, but IDs remain distinct and consistent across re-exports. See Known limitations.
+**JPEG→JPEG case:** When source and export share the same extension, both items have `isOriginal=true`. Sort falls back to `insertionOrder` with the tiebreaker reversed (`>`, higher first): since Lightroom renders the original copy first (insertionOrder=0) and the edited export second (insertionOrder=1), the export sorts first and becomes `items[1]` (primary in Immich), as intended. IDs are always distinct and consistent across re-exports.
 
 **Idempotency:** On re-export, `checkIfAssetExists` finds each asset by exact `deviceAssetId` and calls `replaceAsset` rather than uploading fresh, so repeated exports of the same photo produce exactly one original and one export in one stack.
 
@@ -123,6 +123,22 @@ The dead `else` block is removed from both functions.
 
 ---
 
+### 12. `processPhotoWithStack` called redundantly in `#items >= 2` path (ExportTask.lua)
+
+**Problem:** After uploading both renditions and creating a stack in the `stackOriginalExport` `#items >= 2` branch, the code additionally called `StackManager.processPhotoWithStack`. That function re-fetches the disk original, uploads it under a second `deviceAssetId` (using the `_original` suffix scheme from `generateOriginalDeviceAssetId`), and creates a second Immich stack — resulting in a duplicate original asset and a spurious extra stack.
+
+**Fix:** Removed the `processPhotoWithStack` call from the `#items >= 2` branch. The stack is already created by `immich:createStack(assetIds)` using the renditions that were just uploaded. A comment is left explaining why the call is intentionally absent.
+
+---
+
+### 13. Accumulator keyed on `localIdentifier` instead of stable device ID (ExportTask.lua, PublishTask.lua)
+
+**Problem:** The accumulator in `processStackOriginalExportRenditions` (and its publish counterpart) grouped renditions by `rendition.photo.localIdentifier`, and used that value as the `deviceAssetId` prefix (`lid .. "_export"`/`"_orig"`). The `localIdentifier` is an internal Lightroom database integer that can change if the catalog is recreated or the photo is re-imported, causing the next export to not find previously uploaded assets and creating duplicate uploads.
+
+**Fix:** The accumulator now keys by `util.getPhotoDeviceId(rendition.photo) or rendition.photo.localIdentifier`. `getPhotoDeviceId` returns a stable UUID (same as the single-rendition path uses) when available, falling back to `localIdentifier` only if the UUID is absent. The `exportedPrimaryByPhoto` map still uses `photo.localIdentifier` as its key (required by `applyLrStacksInImmich` which looks up members by `localIdentifier`).
+
+---
+
 ## Format-agnostic cleanup
 
 The original+export stacking feature was implemented with DNG+JPG as the only use case in mind. All format-specific naming and file-type logic has been removed so the feature works correctly for any pairing (DNG+JPG, CR2+TIF, original JPG+export JPG, etc.).
@@ -183,12 +199,12 @@ If any individual upload or stack creation fails, it is reported as a warning af
 
 | File | Changes |
 |------|---------|
-| `ExportTask.lua` | Stack order fix, album primary fix, LR_format guard (×2), role-based deviceAssetId (`_orig`/`_export`) via sort+index, `#items == 1` branch unified and corrected, inline accumulator, missing export-upload warning, format-agnostic renames |
-| `PublishTask.lua` | Role-based deviceAssetId (`_orig`/`_export`) via sort+index, `#items == 1` branch unified and corrected, inline accumulator, format-agnostic renames |
+| `ExportTask.lua` | Stack order fix, album primary fix, LR_format guard (×2), role-based deviceAssetId (`_orig`/`_export`) via sort+index, stable accumulator key (`getPhotoDeviceId`), `#items == 1` branch unified and corrected, removed redundant `processPhotoWithStack`, inline accumulator, missing export-upload warning, format-agnostic renames |
+| `PublishTask.lua` | Role-based deviceAssetId (`_orig`/`_export`) via sort+index, stable accumulator key (`getPhotoDeviceId`), `#items == 1` branch unified and corrected, inline accumulator, format-agnostic renames |
 | `ExportDialogSections.lua` | Warning UI, updated dropdown labels, section label rename, `stackOriginalExport` bind |
 | `PublishDialogSections.lua` | Section label and checkbox text updated, `stackOriginalExport` bind |
 | `ExportServiceProvider.lua` | `stackOriginalExport` preference key |
 | `PublishServiceProvider.lua` | `stackOriginalExport` preference key |
 | `ImmichAPI.lua` | Timeout increases, `HTTP_TIMEOUT_UPLOAD` wired into `postMultipart`, `table.concat` multipart body, explicit POST timeout |
 | `StackManager.lua` | `hasEdits` cache short-circuit and comment fix, removed `getFileType` / `RAW_EXT` |
-| `UploadHelpers.lua` | `sortOriginalExportItems` with extension-based `isOriginal` flag and `insertionOrder` tiebreaker, removed `fileType` field, updated comment |
+| `UploadHelpers.lua` | `sortOriginalExportItems` with extension-based `isOriginal` flag and inverted `insertionOrder` tiebreaker (higher = rendered export = primary), removed `fileType` field, updated comment |

--- a/PR.md
+++ b/PR.md
@@ -29,6 +29,7 @@ This PR fixes the `original_plus_jpeg_if_edited` export mode (issue #91), correc
 **Problem:** When Lightroom's export format is set to "Original / no reformat", Lightroom copies the source file byte-for-byte without rendering an edited version. The plugin then uploaded both copies as if they were distinct, resulting in two identical files in Immich with no meaningful stack.
 
 **Fix:**
+
 - Added a runtime guard in both `processOnePhotoGroup` and `processSingleRenditionRenditions`: if `LR_format == "ORIGINAL"`, skip the rendered export upload and emit a stack warning instead.
 - Added a live warning in the export dialog (orange text) when this incompatible combination is detected.
 - Detection uses `exportParams.LR_format` directly — no hardcoded format lists.
@@ -115,8 +116,8 @@ Edge cases handled:
 
 - Reads `item.isOriginal` to determine the role of the single rendition.
 - Assigns `lid_orig` if the original copy arrived, `lid_export` if the rendered export arrived — consistent with `#items >= 2`.
-- If the export arrived (`isOrig == false`): fetches the disk original via `getOriginalFilePath`, uploads it with `lid_orig`, and creates a stack.
-- If the original arrived (`isOrig == true`): uploads with `lid_orig`; emits a warning if `original_plus_jpeg_if_edited` mode was active and the photo has edits (with the `LR_format == "ORIGINAL"` guard).
+- If the export arrived (`isOrig == false`): in **export mode**, fetches the disk original via `getOriginalFilePath`, uploads it with `lid_orig`, and creates a stack. In **publish mode**, the disk original is intentionally NOT uploaded — an asset uploaded outside `rendition:recordPublishedPhotoId` cannot be tracked by Lightroom and would become an orphan when the photo is later removed from the publish collection (`deletePhotosFromPublishedCollection` only cleans up assets registered via `recordPublishedPhotoId`). A stack warning is emitted instead.
+- If the original arrived (`isOrig == true`): uploads with `lid_orig`; emits a warning if `original_plus_jpeg_if_edited` mode was active and the photo has edits (with the `LR_format == "ORIGINAL"` guard; export path only).
 - Records only the primary in `exportedPrimaryByPhoto` and in the album.
 
 The dead `else` block is removed from both functions.
@@ -198,7 +199,7 @@ If any individual upload or stack creation fails, it is reported as a warning af
 ## Files changed
 
 | File | Changes |
-|------|---------|
+| ---- | ------- |
 | `ExportTask.lua` | Stack order fix, album primary fix, LR_format guard (×2), role-based deviceAssetId (`_orig`/`_export`) via sort+index, stable accumulator key (`getPhotoDeviceId`), `#items == 1` branch unified and corrected, removed redundant `processPhotoWithStack`, inline accumulator, missing export-upload warning, format-agnostic renames |
 | `PublishTask.lua` | Role-based deviceAssetId (`_orig`/`_export`) via sort+index, stable accumulator key (`getPhotoDeviceId`), `#items == 1` branch unified and corrected, inline accumulator, format-agnostic renames |
 | `ExportDialogSections.lua` | Warning UI, updated dropdown labels, section label rename, `stackOriginalExport` bind |

--- a/PR.md
+++ b/PR.md
@@ -159,7 +159,7 @@ The original+export stacking feature was implemented with DNG+JPG as the only us
 
 **Before:** `sortDngJpgItems` sorted by file type (`jpeg=1`, `raw=2`, `other=3`). For pairings where the export is not a JPEG (e.g., DNG+TIF), the sort placed the original first, making it the Immich stack primary — the opposite of the intended behaviour.
 
-**After:** `sortOriginalExportItems` identifies the original by comparing `item.path` to `StackManager.getOriginalFilePath(item.photo)`. The export (non-original) always sorts first regardless of format.
+**After:** `sortOriginalExportItems` uses an `isOriginal` flag set on each item at accumulation time (`isOriginal = itemExt == srcExt`, where `srcExt` is the source file's extension). Items with `isOriginal == false` (the rendered export) sort first; ties fall back to `insertionOrder` (higher = rendered export = sorts first, so the export is always primary regardless of format).
 
 ### File-type checks removed (ExportTask.lua, PublishTask.lua)
 

--- a/PR.md
+++ b/PR.md
@@ -35,11 +35,13 @@ This PR fixes the `original_plus_jpeg_if_edited` export mode (issue #91), correc
 
 ---
 
-### 4. original+export stacking deviceAssetId was position-dependent (ExportTask.lua, PublishTask.lua)
+### 4. original+export stacking deviceAssetId was unstable and collision-prone (ExportTask.lua, PublishTask.lua)
 
-**Problem:** Device asset IDs for multi-rendition groups were generated as `lid_1`, `lid_2` based on loop position. If one rendition failed to render, subsequent files shifted positions and collided with previously uploaded asset IDs on retry, causing Immich's dedup check to match the wrong asset.
+**Problem:** Device asset IDs for multi-rendition groups were generated as `lid_1`, `lid_2` based on loop position. If one rendition failed to render, subsequent files shifted positions and collided with previously uploaded asset IDs on retry, causing Immich's dedup check to match the wrong asset. A subsequent fix to key by file extension (`lid_dng`, `lid_jpg`) addressed position-dependency but introduced a new collision: if both renditions share the same extension (e.g. JPEG source exported as JPEG) or `util.getExtension` returns `""`, both uploads receive the same `deviceAssetId` — Immich deduplicates the wrong asset and stack creation breaks.
 
-**Fix:** Keyed by actual file extension (`lid_dng`, `lid_jpg`, `lid_tif`, etc.) using `util.getExtension(item.path)`. The ID is now stable regardless of rendering failures and agnostic to file format.
+**Fix:** Replaced both approaches with role-based suffixes: `_orig` for the original file (identified by comparing `item.path` to `StackManager.getOriginalFilePath(photo)`) and `_export` for the rendered export. IDs are now stable regardless of rendering failures and unique regardless of file format pairing.
+
+**Idempotency:** On re-export, `checkIfAssetExists` finds each asset by exact `deviceAssetId` and calls `replaceAsset` rather than uploading fresh, so repeated exports of the same photo produce exactly one original and one export in one stack.
 
 ---
 
@@ -51,11 +53,11 @@ This PR fixes the `original_plus_jpeg_if_edited` export mode (issue #91), correc
 
 ---
 
-### 6. Upload timeout too low for large files (ImmichAPI.lua)
+### 6. Upload timeout too low and not consistently applied (ImmichAPI.lua)
 
-**Problem:** `HTTP_TIMEOUT_UPLOAD` was 15 seconds. A 50 MB RAW file at 10 Mbps takes ~40 s; a 100 MB video at 5 Mbps takes ~160 s. Uploads that exceeded 15 s silently failed with no retry. `HTTP_TIMEOUT_DEFAULT` (5 s) was also applied to API calls like stacking and album operations that may legitimately take longer on slow servers.
+**Problem:** `HTTP_TIMEOUT_UPLOAD` was 15 seconds — far too short for large RAW files or slow connections. Uploads that exceeded 15 s silently failed with no retry. `HTTP_TIMEOUT_DEFAULT` (5 s) was also applied to API calls like stacking and album operations that may legitimately take longer on slow servers. Additionally, the main upload path (`uploadAsset` → `doMultiPartPostRequest` → `LrHttp.postMultipart`) had no timeout argument at all, so the constant had no effect on multipart POST uploads even after being increased.
 
-**Fix:** Increased `HTTP_TIMEOUT_UPLOAD` to 300 s (5 min) and `HTTP_TIMEOUT_DEFAULT` to 30 s. Also added an explicit timeout to `doPostRequest`, which previously relied on an undocumented LrHttp default.
+**Fix:** Increased `HTTP_TIMEOUT_UPLOAD` to 300 s (5 min) and `HTTP_TIMEOUT_DEFAULT` to 30 s. Added an explicit timeout to `doPostRequest` (previously relied on an undocumented LrHttp default). Wired `HTTP_TIMEOUT_UPLOAD` into `LrHttp.postMultipart` in `doMultiPartPostRequest` so the timeout now applies to all upload paths.
 
 ---
 
@@ -69,7 +71,7 @@ This PR fixes the `original_plus_jpeg_if_edited` export mode (issue #91), correc
 
 ### 8. `hasEdits` ran redundant catalog queries when cache was present (StackManager.lua)
 
-**Problem:** When an `editedPhotosCache` was provided but the photo was not in it (meaning no edits), the function fell through to a fallback that ran two full `catalog:findPhotos` queries anyway — the same queries that were used to build the cache. For large catalogs this meant two extra full-catalog scans per unedited photo.
+**Problem:** When an `editedPhotosCache` was provided but the photo was not in it (meaning no edits), the function fell through to a fallback that ran two full `catalog:findPhotos` queries anyway — the same queries that were used to build the cache. For large catalogs this meant two extra full-catalog scans per unedited photo. The function header comment also incorrectly implied the fallback always ran.
 
 **Fix:** When a cache is present it is now used exclusively. A cache miss immediately returns `false` without any fallback queries. Function comment updated to accurately describe this behaviour.
 
@@ -157,12 +159,12 @@ If any individual upload or stack creation fails, it is reported as a warning af
 
 | File | Changes |
 |------|---------|
-| `ExportTask.lua` | Stack order fix, album primary fix, LR_format guard (×2), `checkIfAssetExistsEnhanced`, extension-based deviceAssetId, inline accumulator, missing export-upload warning, format-agnostic renames |
-| `PublishTask.lua` | Extension-based deviceAssetId, inline accumulator, format-agnostic renames |
+| `ExportTask.lua` | Stack order fix, album primary fix, LR_format guard (×2), `checkIfAssetExistsEnhanced`, role-based deviceAssetId (`_orig`/`_export`), inline accumulator, missing export-upload warning, format-agnostic renames |
+| `PublishTask.lua` | Role-based deviceAssetId (`_orig`/`_export`), inline accumulator, format-agnostic renames |
 | `ExportDialogSections.lua` | Warning UI, updated dropdown labels, section label rename, `stackOriginalExport` bind |
 | `PublishDialogSections.lua` | Section label and checkbox text updated, `stackOriginalExport` bind |
 | `ExportServiceProvider.lua` | `stackOriginalExport` preference key |
 | `PublishServiceProvider.lua` | `stackOriginalExport` preference key |
-| `ImmichAPI.lua` | Timeout increases, `table.concat` multipart body, explicit POST timeout |
+| `ImmichAPI.lua` | Timeout increases, `HTTP_TIMEOUT_UPLOAD` wired into `postMultipart`, `table.concat` multipart body, explicit POST timeout |
 | `StackManager.lua` | `hasEdits` cache short-circuit and comment fix, removed `getFileType` / `RAW_EXT` |
 | `UploadHelpers.lua` | `sortOriginalExportItems` with path-based sort, removed `fileType` field, updated comment |

--- a/PR.md
+++ b/PR.md
@@ -37,19 +37,21 @@ This PR fixes the `original_plus_jpeg_if_edited` export mode (issue #91), correc
 
 ### 4. original+export stacking deviceAssetId was unstable and collision-prone (ExportTask.lua, PublishTask.lua)
 
-**Problem:** Device asset IDs for multi-rendition groups were generated as `lid_1`, `lid_2` based on loop position. If one rendition failed to render, subsequent files shifted positions and collided with previously uploaded asset IDs on retry, causing Immich's dedup check to match the wrong asset. A subsequent fix to key by file extension (`lid_dng`, `lid_jpg`) addressed position-dependency but introduced a new collision: if both renditions share the same extension (e.g. JPEG source exported as JPEG) or `util.getExtension` returns `""`, both uploads receive the same `deviceAssetId` — Immich deduplicates the wrong asset and stack creation breaks.
+**Problem:** Device asset IDs for multi-rendition groups were generated as `lid_1`, `lid_2` based on loop position. If one rendition failed to render, subsequent files shifted positions and collided with previously uploaded asset IDs on retry, causing Immich's dedup check to match the wrong asset. Keying by file extension (`lid_dng`, `lid_jpg`) addressed position-dependency but introduced a new collision when both renditions share the same extension (e.g. JPEG source exported as JPEG) or `util.getExtension` returns `""` — both uploads receive the same `deviceAssetId` and Immich deduplicates the wrong asset.
 
-**Fix:** Replaced both approaches with role-based suffixes: `_orig` for the original file (identified by comparing `item.path` to `StackManager.getOriginalFilePath(photo)`) and `_export` for the rendered export. IDs are now stable regardless of rendering failures and unique regardless of file format pairing.
+**Fix:** Each item receives an `isOriginal` flag at accumulation time (true if the rendered file's extension matches the source file's extension, indicating an original-format copy) and an `insertionOrder` counter (0-based, evaluated before the item is inserted into the accumulator). `sortOriginalExportItems` sorts items so the export (`isOriginal == false`) comes first; when both items have the same `isOriginal` value, `insertionOrder` is used as a stable tiebreaker. Index-based suffixes are then assigned after the sort: `_export` for `items[1]` (primary in Immich), `_orig` for `items[2]`. IDs are stable regardless of rendering failures and distinct regardless of file format pairing.
+
+**JPEG→JPEG edge case:** When source and export share the same extension, both items have `isOriginal=true`. Sort falls back to `insertionOrder`, so the rendition Lightroom produced first (typically the original copy) becomes `items[1]` and receives the `_export` label; the edited export receives `_orig`. Role labels are semantically inverted for same-extension pairs, but IDs remain distinct and consistent across re-exports. See Known limitations.
 
 **Idempotency:** On re-export, `checkIfAssetExists` finds each asset by exact `deviceAssetId` and calls `replaceAsset` rather than uploading fresh, so repeated exports of the same photo produce exactly one original and one export in one stack.
 
 ---
 
-### 5. `checkIfAssetExists` used inconsistently (ExportTask.lua)
+### 5. `checkIfAssetExistsEnhanced` used in wrong path (ExportTask.lua)
 
-**Problem:** The `original_only` / `original_plus_jpeg_if_edited` path in `processOnePhotoGroup` called the basic `checkIfAssetExists`, while `processSingleRenditionRenditions` called `checkIfAssetExistsEnhanced`. The enhanced version also checks stored Lightroom metadata (`immichAssetId`) and legacy `localIdentifier` uploads. This meant a photo previously exported via one path would not be recognised as already uploaded when re-exported via the other, creating duplicate assets.
+**Problem:** The `stackOriginalExport` multi-rendition path used `checkIfAssetExistsEnhanced` for asset lookups. The enhanced version also checks stored Lightroom `immichAssetId` metadata, which points to the primary (export) asset. Using it in this path risked matching the primary when looking up the original, then calling `replaceAsset` on the wrong asset and corrupting the export.
 
-**Fix:** Changed the `processOnePhotoGroup` original path to use `checkIfAssetExistsEnhanced` consistently.
+**Fix:** The entire `stackOriginalExport` path (`processOnePhotoGroup`, `processPublishOnePhotoGroup`) uses only basic `checkIfAssetExists` via `StackManager.uploadOneAssetOrReplace`, keyed by stable role-based `deviceAssetId` (`_orig`/`_export`). The enhanced check is retained exclusively in `processSingleRenditionRenditions`, where stored metadata correctly identifies the single primary asset per photo.
 
 ---
 
@@ -96,6 +98,28 @@ Edge cases handled:
 **Problem:** In `processOnePhotoGroup`, when the `original_plus_jpeg_if_edited` mode uploaded the original successfully but the rendered export upload returned nil, the failure was silent — no entry was added to `stackWarnings`. The equivalent path in `processSingleRenditionRenditions` did emit a warning.
 
 **Fix:** Added an `else` branch to append `"failed to upload rendered export"` to `stackWarnings` when `exportId` is nil, matching the behaviour of the single-rendition path.
+
+---
+
+### 11. `#items == 1` single-rendition fallback: wrong file, wrong ID, dead code (ExportTask.lua, PublishTask.lua)
+
+**Problem:** When only one of the two expected renditions arrived for a photo (e.g., the export render failed), `processOnePhotoGroup` and `processPublishOnePhotoGroup` fell into a `#items == 1` path with three bugs:
+
+1. **Wrong file uploaded as export.** When `items[1].isOriginal == true` (original copy arrived, export failed to render), the code still uploaded `items[1].path` as the "rendered export" — producing an identical duplicate rather than skipping.
+
+2. **Inconsistent `deviceAssetId` naming.** The path used `lid` (no suffix) for the original and `lid_edited` for the export, while the `#items >= 2` branch used `_orig`/`_export`. On re-export when both renditions arrive, dedup fails to match the previous `lid`/`lid_edited` assets by exact `deviceAssetId`, causing redundant uploads.
+
+3. **Dead `else` block.** Both functions contained an `else` block with a loop over all items including positions `i > 1`. The accumulator flushes at exactly 2 items (handled by `#items >= 2`), so `#items > 2` is unreachable. The `i > 1` loop body was dead code. Additionally, `processPublishOnePhotoGroup` recorded `exportedPrimaryByPhoto[lid]` (inconsistent with `photo.localIdentifier` used in `#items >= 2`) and added each individual item to the album instead of only the primary.
+
+**Fix:** Both functions now have a unified `elseif #items == 1` branch that:
+
+- Reads `item.isOriginal` to determine the role of the single rendition.
+- Assigns `lid_orig` if the original copy arrived, `lid_export` if the rendered export arrived — consistent with `#items >= 2`.
+- If the export arrived (`isOrig == false`): fetches the disk original via `getOriginalFilePath`, uploads it with `lid_orig`, and creates a stack.
+- If the original arrived (`isOrig == true`): uploads with `lid_orig`; emits a warning if `original_plus_jpeg_if_edited` mode was active and the photo has edits (with the `LR_format == "ORIGINAL"` guard).
+- Records only the primary in `exportedPrimaryByPhoto` and in the album.
+
+The dead `else` block is removed from both functions.
 
 ---
 
@@ -159,12 +183,12 @@ If any individual upload or stack creation fails, it is reported as a warning af
 
 | File | Changes |
 |------|---------|
-| `ExportTask.lua` | Stack order fix, album primary fix, LR_format guard (×2), `checkIfAssetExistsEnhanced`, role-based deviceAssetId (`_orig`/`_export`), inline accumulator, missing export-upload warning, format-agnostic renames |
-| `PublishTask.lua` | Role-based deviceAssetId (`_orig`/`_export`), inline accumulator, format-agnostic renames |
+| `ExportTask.lua` | Stack order fix, album primary fix, LR_format guard (×2), role-based deviceAssetId (`_orig`/`_export`) via sort+index, `#items == 1` branch unified and corrected, inline accumulator, missing export-upload warning, format-agnostic renames |
+| `PublishTask.lua` | Role-based deviceAssetId (`_orig`/`_export`) via sort+index, `#items == 1` branch unified and corrected, inline accumulator, format-agnostic renames |
 | `ExportDialogSections.lua` | Warning UI, updated dropdown labels, section label rename, `stackOriginalExport` bind |
 | `PublishDialogSections.lua` | Section label and checkbox text updated, `stackOriginalExport` bind |
 | `ExportServiceProvider.lua` | `stackOriginalExport` preference key |
 | `PublishServiceProvider.lua` | `stackOriginalExport` preference key |
 | `ImmichAPI.lua` | Timeout increases, `HTTP_TIMEOUT_UPLOAD` wired into `postMultipart`, `table.concat` multipart body, explicit POST timeout |
 | `StackManager.lua` | `hasEdits` cache short-circuit and comment fix, removed `getFileType` / `RAW_EXT` |
-| `UploadHelpers.lua` | `sortOriginalExportItems` with path-based sort, removed `fileType` field, updated comment |
+| `UploadHelpers.lua` | `sortOriginalExportItems` with extension-based `isOriginal` flag and `insertionOrder` tiebreaker, removed `fileType` field, updated comment |

--- a/PR.md
+++ b/PR.md
@@ -40,7 +40,7 @@ This PR fixes the `original_plus_jpeg_if_edited` export mode (issue #91), correc
 
 **Problem:** Device asset IDs for multi-rendition groups were generated as `lid_1`, `lid_2` based on loop position. If one rendition failed to render, subsequent files shifted positions and collided with previously uploaded asset IDs on retry, causing Immich's dedup check to match the wrong asset. Keying by file extension (`lid_dng`, `lid_jpg`) addressed position-dependency but introduced a new collision when both renditions share the same extension (e.g. JPEG source exported as JPEG) or `util.getExtension` returns `""` — both uploads receive the same `deviceAssetId` and Immich deduplicates the wrong asset.
 
-**Fix:** Established a role-based `deviceAssetId` scheme: `_export` for the rendered export (primary in Immich) and `_orig` for the disk original. Each item carries an explicit `role` field (`"export"` or `"orig"`). `sortOriginalExportItems` in UploadHelpers.lua sorts items so the export comes first. The `_export`/`_orig` naming is used in both the `#items == 1` path (the active path — see fix #14) and the `#items >= 2` path (kept as a defensive fallback but currently unreachable since LR delivers exactly one rendition per photo).
+**Fix:** Established a role-based `deviceAssetId` scheme: `_export` for the rendered export (primary in Immich) and `_orig` for the disk original. Each item carries an explicit `role` field (`"export"` or `"orig"`). `sortOriginalExportItems` in UploadHelpers.lua sorts items so the export comes first. The `_export`/`_orig` naming is used in both the `#items == 1` path (the active path — see fix #14) and the `#items >= 2` path (kept as a defensive fallback but currently unreachable since LR delivers exactly one rendition per photo). Any hypothetical extra renditions beyond the expected pair receive a `_rend<i>` suffix to keep deviceAssetIds unique.
 
 **Idempotency:** On re-export, `checkIfAssetExists` finds each asset by exact `deviceAssetId` and calls `replaceAsset` rather than uploading fresh, so repeated exports of the same photo produce exactly one original and one export in one stack.
 
@@ -254,15 +254,15 @@ With logging enabled, a typical export now produces clearly readable INFO entrie
 
 **Problem:** Items built in `processStackOriginalExportRenditions` and `processPublishStackOriginalExportRenditions` carried `isOriginal = srcExt ~= "" and itemExt == srcExt` and `insertionOrder = 0` (hard-coded). `sortOriginalExportItems` used `isOriginal` as the primary sort key and `insertionOrder` as a tiebreaker for same-extension pairs. Because both items in a hypothetical two-item group would have `insertionOrder = 0`, ties were nondeterministic — the sort result depended on the Lua runtime's table.sort implementation. In practice the `#items >= 2` branch is unreachable (LR delivers exactly one rendition per photo), but the fields added dead complexity and made the code misleading.
 
-**Fix:** Replaced `isOriginal` and `insertionOrder` with `role = "export"` (set at construction time — LR always delivers the rendered export). `sortOriginalExportItems` now sorts by `a.role == "export"` vs `b.role == "export"`, which is always deterministic and unambiguous regardless of file extension. The `srcPath`/`srcExt`/`itemExt` extraction used only to compute `isOriginal` was removed.
+**Fix:** Replaced `isOriginal` and `insertionOrder` with `role = "export"` (set at construction time — LR always delivers the rendered export). `sortOriginalExportItems` now sorts by `a.role == "export"` vs `b.role == "export"`, which is always deterministic and unambiguous regardless of file extension. The `srcPath`/`srcExt`/`itemExt` extraction used only to compute `isOriginal` was removed. The sort comparator comment no longer claims equal roles stay in place (Lua's `table.sort` is not stable).
 
 ---
 
-### 21. Progress bar not advanced on failed renders in `stackOriginalExport` path (ExportTask.lua, PublishTask.lua)
+### 21. Progress bar not advanced on failed renders (ExportTask.lua, PublishTask.lua)
 
-**Problem:** In `processStackOriginalExportRenditions` and `processPublishStackOriginalExportRenditions`, `done = done + 1` and `progressScope:setPortionComplete(done, nPhotos)` were inside the `if success then` block. If a rendition failed to render (`success == false`), the progress counter was not incremented, so `setPortionComplete` never reached `nPhotos` and the bar stalled below 100% even though the export loop had finished.
+**Problem:** In all four rendition-loop functions (`processStackOriginalExportRenditions`, `processPublishStackOriginalExportRenditions`, `processSingleRenditionRenditions`, `processPublishSingleRenditionRenditions`), `done = done + 1` and `progressScope:setPortionComplete(done, nPhotos)` were inside the `if success then` block. If any rendition failed to render (`success == false`), the progress counter was not incremented, so `setPortionComplete` never reached `nPhotos` and the bar stalled below 100% even though the export loop had finished.
 
-**Fix:** Moved `done = done + 1`, `setPortionComplete`, and the progress log statement outside the `if success then` block so every rendition — successful or failed — advances the bar. Only the upload logic remains inside the success guard.
+**Fix:** Moved `done = done + 1`, `setPortionComplete`, and the progress log statement outside the `if success then` block in all four functions so every rendition — successful or failed — advances the bar. Only the upload logic remains inside the success guard.
 
 ---
 

--- a/PR.md
+++ b/PR.md
@@ -184,6 +184,82 @@ The original+export stacking feature was implemented with DNG+JPG as the only us
 
 ---
 
+### 14. `#items == 1` fallback: same-extension pairs (JPG→JPG, TIF→TIF) not stacked (ExportTask.lua, PublishTask.lua)
+
+**Problem:** When `stackOriginalExport = true` and the source file and export share the same extension (e.g. JPG photos exported as JPEG), the `#items == 1` fallback in `processOnePhotoGroup` / `processPublishOnePhotoGroup` misidentified the single rendition as the original copy and skipped stacking entirely.
+
+Root cause: `LR_exportOriginalFile` is never set in `ExportServiceProvider.lua`, so Lightroom always delivers exactly **one** rendition per photo — the rendered export. The `isOriginal` flag (set as `itemExt == srcExt`) is `true` for same-extension pairs, which caused the code to upload as `_orig` and skip the disk-original fetch and stack creation.
+
+Symptoms observed: exporting 29 536 JPG photos with `stackOriginalExport = true` produced ~43 134 assets in Immich (a mix of unstacked singles and unstacked pairs from a prior partial export) instead of 58 872 stacked pairs. No error or warning was emitted because the warning guard required `originalFileMode == "original_plus_jpeg_if_edited"`, which is not the active value in the `stackOriginalExport` code path.
+
+The bug affected any same-extension pairing (JPG→JPG, TIF→TIF, PNG→PNG, etc.). Different-extension pairings of the same format (`.jpg` vs `.jpeg`, `.tif` vs `.tiff`) were already handled correctly because the normalized extensions differ, giving `isOriginal = false` and taking the stacking path.
+
+**Fix:** Both `processOnePhotoGroup` (ExportTask.lua) and `processPublishOnePhotoGroup` (PublishTask.lua) `#items == 1` branches now always treat the single arriving rendition as the rendered export — `isOrig` determination and branching removed. The `_export` suffix is always used; the disk original is always fetched and uploaded as `_orig`; the stack is always created. In publish mode the disk original is intentionally not uploaded (orphan prevention), and a stack warning is always emitted.
+
+---
+
+### 15. HTTP request failures showed a blocking modal dialog per failure (ImmichAPI.lua)
+
+**Problem:** `handleRequestFailure` called `ErrorHandler.handleError(...)` for every failed HTTP response, which presented a blocking `LrDialogs.presentModalDialog` popup. During a batch export with many photos, each failed stack creation (e.g. HTTP 400 from `/stacks`) triggered a new modal dialog the moment the previous one was dismissed — forcing the user to click through hundreds of identical popups. The return value of the dialog (OK vs Cancel) was also discarded, so Cancel had no effect and the next dialog appeared immediately.
+
+**Fix:** Replaced the `ErrorHandler.handleError` call in `handleRequestFailure` with plain `log:error` calls that record the same information (method, path, status, headers, response body) without showing any dialog. Callers already check the nil return value and add entries to `failures` / `stackWarnings`, which are reported once in the post-export summary via `reportUploadFailuresAndWarnings`.
+
+---
+
+### 16. StackManager.lua always enabled logging regardless of user preference (StackManager.lua)
+
+**Problem:** `StackManager.lua` created its own `local log = LrLogger('ImmichPlugin')` and called `log:enable("logfile")` unconditionally at module load time. This bypassed the global logging preference managed by `Init.lua` — the plugin wrote to `ImmichPlugin.log` on every run regardless of whether the user had enabled logging in the Plugin Manager. Every other file in the plugin uses the global `log` instance from `Init.lua`.
+
+**Fix:** Removed the local `log` declaration and the unconditional `log:enable("logfile")` call. `StackManager.lua` now uses the global `log` variable set by `Init.lua`, matching the pattern used by all other files.
+
+---
+
+### 16. Insufficient INFO-level logging for upload, stack, and flow operations (multiple files)
+
+**Problem:** The plugin had only 3 INFO-level log statements across the entire codebase. Key operations — upload success, stack creation, and the original+export accumulator control flow — produced no INFO output. Diagnosing issues (such as the JPG→JPG stacking bug) required enabling TRACE and sifting through hundreds of low-level entries, or adding temporary code.
+
+Specific gaps:
+
+- `uploadAsset` and `replaceAsset`: no log on success; could not confirm which `deviceAssetId` mapped to which Immich asset ID.
+- `createStack`: logged at TRACE on success; not visible without full TRACE output.
+- `processStackOriginalExportRenditions` accumulator: no log when a photo pair was flushed or an incomplete group was deferred to the single-rendition path.
+- `processOnePhotoGroup` / `processPublishOnePhotoGroup`: no log per upload or per stack attempt.
+- `processSingleRenditionRenditions` (`original_plus_jpeg_if_edited` path): no log for the original or export upload steps.
+
+**Fix:** Added INFO-level logging to the following:
+
+- **ImmichAPI.lua `uploadAsset`**: logs `uploadAsset: <deviceAssetId> -> <assetId>` on success.
+- **ImmichAPI.lua `replaceAsset`**: logs `replaceAsset: <oldId> -> <newId>` on success; changed existing TRACE to INFO.
+- **ImmichAPI.lua `createStack`**: changed TRACE success log to INFO (`Stack created: <id> (N assets)`).
+- **ExportTask.lua / PublishTask.lua accumulator**: logs INFO when a photo pair is flushed (`flushing pair for <filename>`) and when an incomplete single-rendition group is deferred (`flushing incomplete group for <filename>`).
+- **ExportTask.lua / PublishTask.lua `processOnePhotoGroup` / `processPublishOnePhotoGroup`**: logs INFO per upload in `#items >= 2` path; logs INFO announcing single-rendition treatment in `#items == 1` path.
+- **ExportTask.lua `processSingleRenditionRenditions`**: logs INFO when uploading the original and the edited export in the `original_plus_jpeg_if_edited` path.
+
+With logging enabled, a typical JPG→JPG export now produces clearly readable INFO entries showing the accumulator flush, each upload's `deviceAssetId → assetId` mapping, and the stack creation result.
+
+---
+
+### 17. Progress bar advanced prematurely, appeared to go backwards, and disappeared before all uploads completed (ExportTask.lua, PublishTask.lua)
+
+**Problem — premature completion (accumulator):** `processStackOriginalExportRenditions` and `processPublishStackOriginalExportRenditions` used an accumulator that flushed (uploaded) only when *two* renditions for the same photo had arrived (`#accumulator[lid] == 2`). Because `LR_exportOriginalFile` is never set, Lightroom always delivers exactly **one** rendition per photo, so the flush condition was never met during the main loop. All N renditions were rendered (filling the progress bar to 100%) before any upload began; then all uploads happened in a post-loop "flush incomplete groups" pass with the bar already full.
+
+**Problem — bar disappears mid-upload and forward→0→return motion:** `exportContext:configureProgress` creates a progress scope that Lightroom's render pipeline owns and manages. LR renders photos on a background thread; once all N photos are rendered (which happens much faster than uploading), LR closes the `configureProgress` scope automatically — even while the Lua thread is still executing upload HTTP calls. After that, any `setPortionComplete` call on the closed scope is a no-op, so the bar vanishes while uploads continue silently for minutes. The same render-thread ownership caused the forward→0→return jitter: `setPortionComplete(0, nPhotos)` would reset the bar that LR had already partially advanced during pre-initialization API calls, then LR's render thread would re-advance it concurrently with our upload updates.
+
+**Fix:**
+
+1. Removed the accumulator from both functions. Each rendition is now processed (uploaded and stacked) immediately as it arrives, interleaving renders and uploads exactly as `processSingleRenditionRenditions` does.
+2. Replaced `exportContext:configureProgress { title = ... }` with `LrProgressScope { title = ..., functionContext = functionContext }` in both `ExportTask.processRenderedPhotos` and `PublishTask.processRenderedPhotos`. `LrProgressScope` with `functionContext` is owned entirely by the plugin — its lifetime is tied to the function context, so it stays visible until `processRenderedPhotos` returns regardless of when LR finishes rendering. LR's render thread does not advance or close it, eliminating both the early-close and the jitter. `setPortionComplete(done, nPhotos)` after each upload is the sole source of progress updates, so the bar advances monotonically and reaches 100% only when the last upload completes.
+
+---
+
+### 18. Dead code: `generateBoundary`, `generateMultiPartBody`, `createHeadersForMultipartPut`, `doMultiPartPutRequest` (ImmichAPI.lua)
+
+**Problem:** These four functions were left over from an earlier implementation where `replaceAsset` issued a raw multipart PUT request by reading the entire file into memory (`fh:read("*all")`), building the request body as a Lua string, and calling `LrHttp.post` with `method = 'PUT'`. That path was replaced: `replaceAsset` now delegates to `uploadAsset`, which passes the file via `filePath` in the `postMultipart` content table so LR streams it from disk. The old functions had no remaining callers.
+
+**Fix:** Removed all four functions. No behavioral change.
+
+---
+
 ## Known limitations
 
 ### Upload timeout is configurable by editing ImmichAPI.lua
@@ -200,12 +276,12 @@ If any individual upload or stack creation fails, it is reported as a warning af
 
 | File | Changes |
 | ---- | ------- |
-| `ExportTask.lua` | Stack order fix, album primary fix, LR_format guard (×2), role-based deviceAssetId (`_orig`/`_export`) via sort+index, stable accumulator key (`getPhotoDeviceId`), `#items == 1` branch unified and corrected, removed redundant `processPhotoWithStack`, inline accumulator, missing export-upload warning, format-agnostic renames |
-| `PublishTask.lua` | Role-based deviceAssetId (`_orig`/`_export`) via sort+index, stable accumulator key (`getPhotoDeviceId`), `#items == 1` branch unified and corrected (publish: no untracked original upload), removed unused `exportParams` from `processPublishStackOriginalExportRenditions`, inline accumulator, format-agnostic renames |
+| `ExportTask.lua` | Stack order fix, album primary fix, LR_format guard (×2), role-based deviceAssetId (`_orig`/`_export`) via sort+index, stable accumulator key (`getPhotoDeviceId`), `#items == 1` branch unified and corrected (always treat as export; fetch disk original; stack), removed redundant `processPhotoWithStack`, per-rendition immediate processing (no accumulator; fixes progress bar), `LrProgressScope { functionContext }` replaces `configureProgress` (bar stays alive until all uploads done; no forward→0→return jitter), missing export-upload warning, format-agnostic renames |
+| `PublishTask.lua` | Role-based deviceAssetId (`_orig`/`_export`) via sort+index, stable accumulator key (`getPhotoDeviceId`), `#items == 1` branch unified and corrected (always treat as export; orphan-safe warning), removed unused `exportParams` from `processPublishStackOriginalExportRenditions`, per-rendition immediate processing (no accumulator; fixes progress bar), `LrProgressScope { functionContext }` replaces `configureProgress` (bar stays alive until all uploads done; no forward→0→return jitter), format-agnostic renames |
 | `ExportDialogSections.lua` | Warning UI, updated dropdown labels, section label rename, `stackOriginalExport` bind |
 | `PublishDialogSections.lua` | Section label and checkbox text updated, `stackOriginalExport` bind |
 | `ExportServiceProvider.lua` | `stackOriginalExport` preference key |
 | `PublishServiceProvider.lua` | `stackOriginalExport` preference key |
-| `ImmichAPI.lua` | Timeout increases, `HTTP_TIMEOUT_UPLOAD` wired into `postMultipart`, `table.concat` multipart body, explicit POST timeout |
+| `ImmichAPI.lua` | Timeout increases, `HTTP_TIMEOUT_UPLOAD` wired into `postMultipart`, `table.concat` multipart body, explicit POST timeout, `handleRequestFailure` changed to log-only (no modal dialog), INFO logging for `uploadAsset`/`replaceAsset`/`createStack` success, removed dead `generateBoundary`/`generateMultiPartBody`/`createHeadersForMultipartPut`/`doMultiPartPutRequest` (no callers since `replaceAsset` was rewritten to delegate to `uploadAsset`) |
 | `StackManager.lua` | `hasEdits` cache short-circuit and comment fix, removed `getFileType` / `RAW_EXT` |
 | `UploadHelpers.lua` | `sortOriginalExportItems` with extension-based `isOriginal` flag and inverted `insertionOrder` tiebreaker (higher = rendered export = primary), removed `fileType` field, removed dead `collectRenditions`/`groupByPhoto`, updated comment |

--- a/PR.md
+++ b/PR.md
@@ -84,7 +84,7 @@ This PR fixes the `original_plus_jpeg_if_edited` export mode (issue #91), correc
 
 **Problem:** `processStackOriginalExportRenditions` (and its publish counterpart) called `UploadHelpers.collectRenditions`, which waited for every rendition across the entire export batch to finish rendering before the first upload began. On large exports this caused all temp files to accumulate on disk simultaneously, risking temp-disk exhaustion and delaying any upload feedback.
 
-**Fix:** Replaced `collectRenditions` + `groupByPhoto` with an inline accumulator loop in both `processStackOriginalExportRenditions` (ExportTask.lua) and `processPublishStackOriginalExportRenditions` (PublishTask.lua). Each photo group is flushed — uploaded, stacked, temp files deleted — as soon as both of its renditions have arrived. Groups where one rendition failed to render are flushed as a single-item group at the end of the loop. `UploadHelpers.collectRenditions` and `groupByPhoto` are retained for other callers.
+**Fix:** Replaced `collectRenditions` + `groupByPhoto` with an inline accumulator loop in both `processStackOriginalExportRenditions` (ExportTask.lua) and `processPublishStackOriginalExportRenditions` (PublishTask.lua). Each photo group is flushed — uploaded, stacked, temp files deleted — as soon as both of its renditions have arrived. Groups where one rendition failed to render are flushed as a single-item group at the end of the loop. `UploadHelpers.collectRenditions` and `groupByPhoto` had no remaining callers after this change and were removed.
 
 Edge cases handled:
 
@@ -201,11 +201,11 @@ If any individual upload or stack creation fails, it is reported as a warning af
 | File | Changes |
 | ---- | ------- |
 | `ExportTask.lua` | Stack order fix, album primary fix, LR_format guard (×2), role-based deviceAssetId (`_orig`/`_export`) via sort+index, stable accumulator key (`getPhotoDeviceId`), `#items == 1` branch unified and corrected, removed redundant `processPhotoWithStack`, inline accumulator, missing export-upload warning, format-agnostic renames |
-| `PublishTask.lua` | Role-based deviceAssetId (`_orig`/`_export`) via sort+index, stable accumulator key (`getPhotoDeviceId`), `#items == 1` branch unified and corrected, inline accumulator, format-agnostic renames |
+| `PublishTask.lua` | Role-based deviceAssetId (`_orig`/`_export`) via sort+index, stable accumulator key (`getPhotoDeviceId`), `#items == 1` branch unified and corrected (publish: no untracked original upload), removed unused `exportParams` from `processPublishStackOriginalExportRenditions`, inline accumulator, format-agnostic renames |
 | `ExportDialogSections.lua` | Warning UI, updated dropdown labels, section label rename, `stackOriginalExport` bind |
 | `PublishDialogSections.lua` | Section label and checkbox text updated, `stackOriginalExport` bind |
 | `ExportServiceProvider.lua` | `stackOriginalExport` preference key |
 | `PublishServiceProvider.lua` | `stackOriginalExport` preference key |
 | `ImmichAPI.lua` | Timeout increases, `HTTP_TIMEOUT_UPLOAD` wired into `postMultipart`, `table.concat` multipart body, explicit POST timeout |
 | `StackManager.lua` | `hasEdits` cache short-circuit and comment fix, removed `getFileType` / `RAW_EXT` |
-| `UploadHelpers.lua` | `sortOriginalExportItems` with extension-based `isOriginal` flag and inverted `insertionOrder` tiebreaker (higher = rendered export = primary), removed `fileType` field, updated comment |
+| `UploadHelpers.lua` | `sortOriginalExportItems` with extension-based `isOriginal` flag and inverted `insertionOrder` tiebreaker (higher = rendered export = primary), removed `fileType` field, removed dead `collectRenditions`/`groupByPhoto`, updated comment |

--- a/PR.md
+++ b/PR.md
@@ -26,12 +26,13 @@ This PR fixes the `original_plus_jpeg_if_edited` export mode (issue #91), correc
 
 ### 3. "Original / no reformat" produced two identical uploads (ExportTask.lua, ExportDialogSections.lua)
 
-**Problem:** When Lightroom's export format is set to "Original / no reformat", Lightroom copies the source file byte-for-byte without rendering an edited version. The plugin then uploaded both copies as if they were distinct, resulting in two identical files in Immich with no meaningful stack.
+**Problem:** When Lightroom's export format is set to "Original / no reformat", Lightroom copies the source file byte-for-byte without rendering an edited version. The plugin then uploaded both copies as if they were distinct, resulting in two identical files in Immich with no meaningful stack. This affected both the `original_plus_jpeg_if_edited` single-rendition path and the `stackOriginalExport` path.
 
 **Fix:**
 
 - Added a runtime guard in `processSingleRenditionRenditions` (`original_plus_jpeg_if_edited` path): if `LR_format == "ORIGINAL"`, skip the rendered export upload and emit a stack warning instead.
-- Added a live warning in the export dialog (orange text) when this incompatible combination is detected, discouraging the combination before export starts.
+- Added the same guard in `processOnePhotoGroup` (`stackOriginalExport` path, `#items == 1` branch): if `LR_format == "ORIGINAL"`, skip the disk-original upload and stack creation and emit a warning.
+- Added a live warning in the export dialog (orange text) when this incompatible combination is detected — fires whenever `LR_format == "ORIGINAL"` and either `original_plus_jpeg_if_edited` or `stackOriginalExport` is active. An observer on `stackOriginalExport` ensures the warning appears/clears reactively when the checkbox is toggled.
 - Detection uses `exportParams.LR_format` directly — no hardcoded format lists.
 
 ---
@@ -167,7 +168,7 @@ The original+export stacking feature was implemented with DNG+JPG as the only us
 
 ## UI improvements
 
-- **ExportDialogSections.lua:** Dropdown labels updated to be format-agnostic; "Original / no reformat" warning added (orange text).
+- **ExportDialogSections.lua:** Dropdown labels updated to be format-agnostic; "Original / no reformat" warning added (orange text) — fires when `LR_format == "ORIGINAL"` and either `original_plus_jpeg_if_edited` or `stackOriginalExport` is active; observer added for `stackOriginalExport` so the warning reacts when the checkbox is toggled.
 - **PublishDialogSections.lua:** Stack section label `"DNG+JPG:"` → `"Original + Export:"`, checkbox `"Stack in Immich (edited JPG as primary)"` → `"Stack in Immich (export as primary)"`.
 
 > **Note:** The `stackDngJpg` preference key has been renamed to `stackOriginalExport`. Users with existing export presets or publish collections that had the stacking checkbox enabled will need to re-enable it after updating.
@@ -290,9 +291,9 @@ If any individual upload or stack creation fails, it is reported as a warning af
 
 | File | Changes |
 | ---- | ------- |
-| `ExportTask.lua` | Stack order fix, album primary fix, LR_format guard (×2), role-based deviceAssetId (`_orig`/`_export`) via sort+index, stable accumulator key (`getPhotoDeviceId`), `#items == 1` branch unified and corrected (always treat as export; fetch disk original; stack), removed redundant `processPhotoWithStack`, per-rendition immediate processing (no accumulator; fixes progress bar), `LrProgressScope { functionContext }` replaces `configureProgress` (bar stays alive until all uploads done; no forward→0→return jitter), missing export-upload warning, `role = "export"` replaces `isOriginal`/`insertionOrder`, progress advances on failed renders, `progressScope:done()` on completion, format-agnostic renames |
-| `PublishTask.lua` | Role-based deviceAssetId (`_orig`/`_export`) via sort+index, stable accumulator key (`getPhotoDeviceId`), `#items == 1` branch unified and corrected (always treat as export; orphan-safe warning), removed unused `exportParams` from `processPublishStackOriginalExportRenditions`, per-rendition immediate processing (no accumulator; fixes progress bar), `LrProgressScope { functionContext }` replaces `configureProgress` (bar stays alive until all uploads done; no forward→0→return jitter), `role = "export"` replaces `isOriginal`/`insertionOrder`, progress advances on failed renders, `progressScope:done()` on completion, format-agnostic renames |
-| `ExportDialogSections.lua` | Warning UI, updated dropdown labels, section label rename, `stackOriginalExport` bind |
+| `ExportTask.lua` | Stack order fix, album primary fix, LR_format=ORIGINAL guard in both `original_plus_jpeg_if_edited` and `stackOriginalExport` paths (skip identical upload; warn), role-based deviceAssetId (`_orig`/`_export`, `_rend<i>` for extras), stable accumulator key (`getPhotoDeviceId`), `#items == 1` branch unified and corrected (always treat as export; fetch disk original; stack), removed redundant `processPhotoWithStack`, per-rendition immediate processing (no accumulator; fixes progress bar), `LrProgressScope { functionContext }` replaces `configureProgress` (bar stays alive until all uploads done; no forward→0→return jitter), missing export-upload warning, `role = "export"` replaces `isOriginal`/`insertionOrder`, progress advances on failed renders, `progressScope:done()` on completion, format-agnostic renames |
+| `PublishTask.lua` | Role-based deviceAssetId (`_orig`/`_export`, `_rend<i>` for extras), stable accumulator key (`getPhotoDeviceId`), `#items == 1` branch unified and corrected (always treat as export; orphan-safe single-warning), removed unused `exportParams` from `processPublishStackOriginalExportRenditions`, per-rendition immediate processing (no accumulator; fixes progress bar), `LrProgressScope { functionContext }` replaces `configureProgress` (bar stays alive until all uploads done; no forward→0→return jitter), `role = "export"` replaces `isOriginal`/`insertionOrder`, progress advances on failed renders, `progressScope:done()` on completion, format-agnostic renames |
+| `ExportDialogSections.lua` | Warning UI fires for both `original_plus_jpeg_if_edited` and `stackOriginalExport` when `LR_format=ORIGINAL`; observer added for `stackOriginalExport`; updated dropdown labels; section label rename; `stackOriginalExport` bind |
 | `PublishDialogSections.lua` | Section label and checkbox text updated, `stackOriginalExport` bind |
 | `ExportServiceProvider.lua` | `stackOriginalExport` preference key |
 | `PublishServiceProvider.lua` | `stackOriginalExport` preference key |

--- a/PR.md
+++ b/PR.md
@@ -40,7 +40,7 @@ This PR fixes the `original_plus_jpeg_if_edited` export mode (issue #91), correc
 
 **Problem:** Device asset IDs for multi-rendition groups were generated as `lid_1`, `lid_2` based on loop position. If one rendition failed to render, subsequent files shifted positions and collided with previously uploaded asset IDs on retry, causing Immich's dedup check to match the wrong asset. Keying by file extension (`lid_dng`, `lid_jpg`) addressed position-dependency but introduced a new collision when both renditions share the same extension (e.g. JPEG source exported as JPEG) or `util.getExtension` returns `""` — both uploads receive the same `deviceAssetId` and Immich deduplicates the wrong asset.
 
-**Fix:** Established a role-based `deviceAssetId` scheme: `_export` for the rendered export (primary in Immich) and `_orig` for the disk original. Each item receives an `isOriginal` flag (true if the rendered file's extension matches the source file's extension) and an `insertionOrder` counter to support sorting. `sortOriginalExportItems` in UploadHelpers.lua sorts items so the export comes first. The `_export`/`_orig` naming is used in both the `#items == 1` path (the active path — see fix #14) and the `#items >= 2` path (kept as a defensive fallback but currently unreachable since LR delivers exactly one rendition per photo).
+**Fix:** Established a role-based `deviceAssetId` scheme: `_export` for the rendered export (primary in Immich) and `_orig` for the disk original. Each item carries an explicit `role` field (`"export"` or `"orig"`). `sortOriginalExportItems` in UploadHelpers.lua sorts items so the export comes first. The `_export`/`_orig` naming is used in both the `#items == 1` path (the active path — see fix #14) and the `#items >= 2` path (kept as a defensive fallback but currently unreachable since LR delivers exactly one rendition per photo).
 
 **Idempotency:** On re-export, `checkIfAssetExists` finds each asset by exact `deviceAssetId` and calls `replaceAsset` rather than uploading fresh, so repeated exports of the same photo produce exactly one original and one export in one stack.
 
@@ -106,10 +106,8 @@ This PR fixes the `original_plus_jpeg_if_edited` export mode (issue #91), correc
 
 **Fix:** Both functions now have a unified `elseif #items == 1` branch that:
 
-- Reads `item.isOriginal` to determine the role of the single rendition.
-- Assigns `lid_orig` if the original copy arrived, `lid_export` if the rendered export arrived — consistent with `#items >= 2`.
-- If the export arrived (`isOrig == false`): in **export mode**, fetches the disk original via `getOriginalFilePath`, uploads it with `lid_orig`, and creates a stack. In **publish mode**, the disk original is intentionally NOT uploaded — an asset uploaded outside `rendition:recordPublishedPhotoId` cannot be tracked by Lightroom and would become an orphan when the photo is later removed from the publish collection (`deletePhotosFromPublishedCollection` only cleans up assets registered via `recordPublishedPhotoId`). A stack warning is emitted instead.
-- If the original arrived (`isOrig == true`): uploads with `lid_orig`; emits a warning if `original_plus_jpeg_if_edited` mode was active and the photo has edits (with the `LR_format == "ORIGINAL"` guard; export path only).
+- Assigns `lid_export` for the rendition and fetches the disk original separately — consistent with `#items >= 2`.
+- In **export mode**, fetches the disk original via `getOriginalFilePath`, uploads it with `lid_orig`, and creates a stack. In **publish mode**, the disk original is intentionally NOT uploaded — an asset uploaded outside `rendition:recordPublishedPhotoId` cannot be tracked by Lightroom and would become an orphan when the photo is later removed from the publish collection (`deletePhotosFromPublishedCollection` only cleans up assets registered via `recordPublishedPhotoId`). A stack warning is emitted instead.
 - Records only the primary in `exportedPrimaryByPhoto` and in the album.
 
 The dead `else` block is removed from both functions.
@@ -152,7 +150,7 @@ The original+export stacking feature was implemented with DNG+JPG as the only us
 
 **Before:** `sortDngJpgItems` sorted by file type (`jpeg=1`, `raw=2`, `other=3`). For pairings where the export is not a JPEG (e.g., DNG+TIF), the sort placed the original first, making it the Immich stack primary — the opposite of the intended behaviour.
 
-**After:** `sortOriginalExportItems` uses an `isOriginal` flag set on each item at accumulation time (`isOriginal = itemExt == srcExt`, where `srcExt` is the source file's extension). Items with `isOriginal == false` (the rendered export) sort first; ties fall back to `insertionOrder` (higher = rendered export = sorts first, so the export is always primary regardless of format).
+**After:** `sortOriginalExportItems` uses an explicit `role` field (`"export"` or `"orig"`) set on each item at construction time. Items with `role == "export"` sort first, so the export is always primary regardless of format or file extension (see also fix #20).
 
 ### File-type checks removed (ExportTask.lua, PublishTask.lua)
 
@@ -180,13 +178,13 @@ The original+export stacking feature was implemented with DNG+JPG as the only us
 
 **Problem:** When `stackOriginalExport = true` and the source file and export share the same extension (e.g. JPG photos exported as JPEG), the `#items == 1` fallback in `processOnePhotoGroup` / `processPublishOnePhotoGroup` misidentified the single rendition as the original copy and skipped stacking entirely.
 
-Root cause: `LR_exportOriginalFile` is never set in `ExportServiceProvider.lua`, so Lightroom always delivers exactly **one** rendition per photo — the rendered export. The `isOriginal` flag (set as `itemExt == srcExt`) is `true` for same-extension pairs, which caused the code to upload as `_orig` and skip the disk-original fetch and stack creation.
+Root cause: `LR_exportOriginalFile` is never set in `ExportServiceProvider.lua`, so Lightroom always delivers exactly **one** rendition per photo — the rendered export. The `isOriginal` flag (then set as `itemExt == srcExt`) was `true` for same-extension pairs, which caused the code to upload as `_orig` and skip the disk-original fetch and stack creation.
 
 Symptoms observed: exporting 29 536 JPG photos with `stackOriginalExport = true` produced ~43 134 assets in Immich (a mix of unstacked singles and unstacked pairs from a prior partial export) instead of 58 872 stacked pairs. No error or warning was emitted because the warning guard required `originalFileMode == "original_plus_jpeg_if_edited"`, which is not the active value in the `stackOriginalExport` code path.
 
 The bug affected any same-extension pairing (JPG→JPG, TIF→TIF, PNG→PNG, etc.). Different-extension pairings of the same format (`.jpg` vs `.jpeg`, `.tif` vs `.tiff`) were already handled correctly because the normalized extensions differ, giving `isOriginal = false` and taking the stacking path.
 
-**Fix:** Both `processOnePhotoGroup` (ExportTask.lua) and `processPublishOnePhotoGroup` (PublishTask.lua) `#items == 1` branches now always treat the single arriving rendition as the rendered export — `isOrig` determination and branching removed. The `_export` suffix is always used; the disk original is always fetched and uploaded as `_orig`; the stack is always created. In publish mode the disk original is intentionally not uploaded (orphan prevention), and a stack warning is always emitted.
+**Fix:** Both `processOnePhotoGroup` (ExportTask.lua) and `processPublishOnePhotoGroup` (PublishTask.lua) `#items == 1` branches now always treat the single arriving rendition as the rendered export. The `_export` suffix is always used; the disk original is always fetched and uploaded as `_orig`; the stack is always created. In publish mode the disk original is intentionally not uploaded (orphan prevention), and a stack warning is always emitted.
 
 ---
 
@@ -252,6 +250,30 @@ With logging enabled, a typical export now produces clearly readable INFO entrie
 
 ---
 
+### 20. `isOriginal`/`insertionOrder` item fields replaced with explicit `role` field (UploadHelpers.lua, ExportTask.lua, PublishTask.lua)
+
+**Problem:** Items built in `processStackOriginalExportRenditions` and `processPublishStackOriginalExportRenditions` carried `isOriginal = srcExt ~= "" and itemExt == srcExt` and `insertionOrder = 0` (hard-coded). `sortOriginalExportItems` used `isOriginal` as the primary sort key and `insertionOrder` as a tiebreaker for same-extension pairs. Because both items in a hypothetical two-item group would have `insertionOrder = 0`, ties were nondeterministic — the sort result depended on the Lua runtime's table.sort implementation. In practice the `#items >= 2` branch is unreachable (LR delivers exactly one rendition per photo), but the fields added dead complexity and made the code misleading.
+
+**Fix:** Replaced `isOriginal` and `insertionOrder` with `role = "export"` (set at construction time — LR always delivers the rendered export). `sortOriginalExportItems` now sorts by `a.role == "export"` vs `b.role == "export"`, which is always deterministic and unambiguous regardless of file extension. The `srcPath`/`srcExt`/`itemExt` extraction used only to compute `isOriginal` was removed.
+
+---
+
+### 21. Progress bar not advanced on failed renders in `stackOriginalExport` path (ExportTask.lua, PublishTask.lua)
+
+**Problem:** In `processStackOriginalExportRenditions` and `processPublishStackOriginalExportRenditions`, `done = done + 1` and `progressScope:setPortionComplete(done, nPhotos)` were inside the `if success then` block. If a rendition failed to render (`success == false`), the progress counter was not incremented, so `setPortionComplete` never reached `nPhotos` and the bar stalled below 100% even though the export loop had finished.
+
+**Fix:** Moved `done = done + 1`, `setPortionComplete`, and the progress log statement outside the `if success then` block so every rendition — successful or failed — advances the bar. Only the upload logic remains inside the success guard.
+
+---
+
+### 22. `LrProgressScope` not closed explicitly (ExportTask.lua, PublishTask.lua)
+
+**Problem:** `ExportTask.processRenderedPhotos` and `PublishTask.processRenderedPhotos` created a `LrProgressScope` but never called `progressScope:done()`. Cleanup relied on the `functionContext` finalizer. While this works in practice, it is non-deterministic: the scope remains visible until Lua's garbage collector or the context cleanup disposes it, which can leave a stale progress indicator briefly after the function returns.
+
+**Fix:** Added `progressScope:done()` immediately after `runExport` / `runPublishExport` returns, before the final log and `reportUploadFailuresAndWarnings` call, closing the scope deterministically at the earliest safe point.
+
+---
+
 ## Known limitations
 
 ### Upload timeout is configurable by editing ImmichAPI.lua
@@ -268,12 +290,12 @@ If any individual upload or stack creation fails, it is reported as a warning af
 
 | File | Changes |
 | ---- | ------- |
-| `ExportTask.lua` | Stack order fix, album primary fix, LR_format guard (×2), role-based deviceAssetId (`_orig`/`_export`) via sort+index, stable accumulator key (`getPhotoDeviceId`), `#items == 1` branch unified and corrected (always treat as export; fetch disk original; stack), removed redundant `processPhotoWithStack`, per-rendition immediate processing (no accumulator; fixes progress bar), `LrProgressScope { functionContext }` replaces `configureProgress` (bar stays alive until all uploads done; no forward→0→return jitter), missing export-upload warning, format-agnostic renames |
-| `PublishTask.lua` | Role-based deviceAssetId (`_orig`/`_export`) via sort+index, stable accumulator key (`getPhotoDeviceId`), `#items == 1` branch unified and corrected (always treat as export; orphan-safe warning), removed unused `exportParams` from `processPublishStackOriginalExportRenditions`, per-rendition immediate processing (no accumulator; fixes progress bar), `LrProgressScope { functionContext }` replaces `configureProgress` (bar stays alive until all uploads done; no forward→0→return jitter), format-agnostic renames |
+| `ExportTask.lua` | Stack order fix, album primary fix, LR_format guard (×2), role-based deviceAssetId (`_orig`/`_export`) via sort+index, stable accumulator key (`getPhotoDeviceId`), `#items == 1` branch unified and corrected (always treat as export; fetch disk original; stack), removed redundant `processPhotoWithStack`, per-rendition immediate processing (no accumulator; fixes progress bar), `LrProgressScope { functionContext }` replaces `configureProgress` (bar stays alive until all uploads done; no forward→0→return jitter), missing export-upload warning, `role = "export"` replaces `isOriginal`/`insertionOrder`, progress advances on failed renders, `progressScope:done()` on completion, format-agnostic renames |
+| `PublishTask.lua` | Role-based deviceAssetId (`_orig`/`_export`) via sort+index, stable accumulator key (`getPhotoDeviceId`), `#items == 1` branch unified and corrected (always treat as export; orphan-safe warning), removed unused `exportParams` from `processPublishStackOriginalExportRenditions`, per-rendition immediate processing (no accumulator; fixes progress bar), `LrProgressScope { functionContext }` replaces `configureProgress` (bar stays alive until all uploads done; no forward→0→return jitter), `role = "export"` replaces `isOriginal`/`insertionOrder`, progress advances on failed renders, `progressScope:done()` on completion, format-agnostic renames |
 | `ExportDialogSections.lua` | Warning UI, updated dropdown labels, section label rename, `stackOriginalExport` bind |
 | `PublishDialogSections.lua` | Section label and checkbox text updated, `stackOriginalExport` bind |
 | `ExportServiceProvider.lua` | `stackOriginalExport` preference key |
 | `PublishServiceProvider.lua` | `stackOriginalExport` preference key |
 | `ImmichAPI.lua` | Timeout increases, `HTTP_TIMEOUT_UPLOAD` wired into `postMultipart`, explicit POST timeout, `handleRequestFailure` changed to log-only (no modal dialog), INFO logging for `uploadAsset`/`replaceAsset`/`createStack` success, `replaceAsset` delegates to `uploadAsset` (LR streams file from disk via `filePath` in `postMultipart` — no in-memory file copy), removed dead `generateBoundary`/`generateMultiPartBody`/`createHeadersForMultipartPut`/`doMultiPartPutRequest` |
 | `StackManager.lua` | `hasEdits` cache short-circuit and comment fix, removed `getFileType` / `RAW_EXT` |
-| `UploadHelpers.lua` | `sortOriginalExportItems` with extension-based `isOriginal` flag and inverted `insertionOrder` tiebreaker (higher = rendered export = primary), removed `fileType` field, removed dead `collectRenditions`/`groupByPhoto`, updated comment |
+| `UploadHelpers.lua` | `sortOriginalExportItems` with explicit `role` field (replaces `isOriginal`/`insertionOrder`; deterministic for same-extension pairs), removed `fileType` field, removed dead `collectRenditions`/`groupByPhoto`, updated comment |

--- a/PR.md
+++ b/PR.md
@@ -30,8 +30,8 @@ This PR fixes the `original_plus_jpeg_if_edited` export mode (issue #91), correc
 
 **Fix:**
 
-- Added a runtime guard in both `processOnePhotoGroup` and `processSingleRenditionRenditions`: if `LR_format == "ORIGINAL"`, skip the rendered export upload and emit a stack warning instead.
-- Added a live warning in the export dialog (orange text) when this incompatible combination is detected.
+- Added a runtime guard in `processSingleRenditionRenditions` (`original_plus_jpeg_if_edited` path): if `LR_format == "ORIGINAL"`, skip the rendered export upload and emit a stack warning instead.
+- Added a live warning in the export dialog (orange text) when this incompatible combination is detected, discouraging the combination before export starts.
 - Detection uses `exportParams.LR_format` directly — no hardcoded format lists.
 
 ---
@@ -40,9 +40,7 @@ This PR fixes the `original_plus_jpeg_if_edited` export mode (issue #91), correc
 
 **Problem:** Device asset IDs for multi-rendition groups were generated as `lid_1`, `lid_2` based on loop position. If one rendition failed to render, subsequent files shifted positions and collided with previously uploaded asset IDs on retry, causing Immich's dedup check to match the wrong asset. Keying by file extension (`lid_dng`, `lid_jpg`) addressed position-dependency but introduced a new collision when both renditions share the same extension (e.g. JPEG source exported as JPEG) or `util.getExtension` returns `""` — both uploads receive the same `deviceAssetId` and Immich deduplicates the wrong asset.
 
-**Fix:** Each item receives an `isOriginal` flag at accumulation time (true if the rendered file's extension matches the source file's extension, indicating an original-format copy) and an `insertionOrder` counter (0-based, evaluated before the item is inserted into the accumulator). `sortOriginalExportItems` sorts items so the export (`isOriginal == false`) comes first; when both items have the same `isOriginal` value, `insertionOrder` is used as a stable tiebreaker. Index-based suffixes are then assigned after the sort: `_export` for `items[1]` (primary in Immich), `_orig` for `items[2]`. IDs are stable regardless of rendering failures and distinct regardless of file format pairing.
-
-**JPEG→JPEG case:** When source and export share the same extension, both items have `isOriginal=true`. Sort falls back to `insertionOrder` with the tiebreaker reversed (`>`, higher first): since Lightroom renders the original copy first (insertionOrder=0) and the edited export second (insertionOrder=1), the export sorts first and becomes `items[1]` (primary in Immich), as intended. IDs are always distinct and consistent across re-exports.
+**Fix:** Established a role-based `deviceAssetId` scheme: `_export` for the rendered export (primary in Immich) and `_orig` for the disk original. Each item receives an `isOriginal` flag (true if the rendered file's extension matches the source file's extension) and an `insertionOrder` counter to support sorting. `sortOriginalExportItems` in UploadHelpers.lua sorts items so the export comes first. The `_export`/`_orig` naming is used in both the `#items == 1` path (the active path — see fix #14) and the `#items >= 2` path (kept as a defensive fallback but currently unreachable since LR delivers exactly one rendition per photo).
 
 **Idempotency:** On re-export, `checkIfAssetExists` finds each asset by exact `deviceAssetId` and calls `replaceAsset` rather than uploading fresh, so repeated exports of the same photo produce exactly one original and one export in one stack.
 
@@ -64,11 +62,11 @@ This PR fixes the `original_plus_jpeg_if_edited` export mode (issue #91), correc
 
 ---
 
-### 7. High memory usage when replacing assets (ImmichAPI.lua)
+### 7. High memory usage when uploading assets (ImmichAPI.lua)
 
-**Problem:** `generateMultiPartBody` built the multipart request body using repeated Lua string concatenation (`body = body .. chunk`). Lua strings are immutable, so each `..` allocated a new copy of all previous content. For a 50 MB RAW file this created ~100 MB of peak heap pressure just to build the request body.
+**Problem:** The original `replaceAsset` path called `doMultiPartPutRequest`, which called `generateMultiPartBody` to build the multipart body by reading the entire file into memory (`fh:read("*all")`). For a 50 MB RAW file this created ~50 MB of peak heap pressure just for the request body, plus additional copies during string concatenation.
 
-**Fix:** Accumulated body parts in a Lua table and called `table.concat(parts)` once at the end, performing a single allocation.
+**Fix:** `replaceAsset` now delegates to `uploadAsset`, which passes the file via a `filePath` entry in the `LrHttp.postMultipart` content table. Lightroom streams the file directly from disk — no in-memory copy of the file content is made at all. The old `generateMultiPartBody`, `doMultiPartPutRequest`, `createHeadersForMultipartPut`, and `generateBoundary` functions were removed as dead code (see fix #19).
 
 ---
 
@@ -80,17 +78,11 @@ This PR fixes the `original_plus_jpeg_if_edited` export mode (issue #91), correc
 
 ---
 
-### 9. Inline accumulator replaces batch-collect in original+export flow (ExportTask.lua, PublishTask.lua)
+### 9. Inline processing replaces batch-collect in original+export flow (ExportTask.lua, PublishTask.lua)
 
 **Problem:** `processStackOriginalExportRenditions` (and its publish counterpart) called `UploadHelpers.collectRenditions`, which waited for every rendition across the entire export batch to finish rendering before the first upload began. On large exports this caused all temp files to accumulate on disk simultaneously, risking temp-disk exhaustion and delaying any upload feedback.
 
-**Fix:** Replaced `collectRenditions` + `groupByPhoto` with an inline accumulator loop in both `processStackOriginalExportRenditions` (ExportTask.lua) and `processPublishStackOriginalExportRenditions` (PublishTask.lua). Each photo group is flushed — uploaded, stacked, temp files deleted — as soon as both of its renditions have arrived. Groups where one rendition failed to render are flushed as a single-item group at the end of the loop. `UploadHelpers.collectRenditions` and `groupByPhoto` had no remaining callers after this change and were removed.
-
-Edge cases handled:
-
-- Render failure on one of a pair → single-item flush at end; `processOnePhotoGroup` already handles the 1-item case.
-- Cancellation mid-export → already-flushed groups have temp files deleted; in-progress accumulator items remain (same as single-rendition path).
-- Interleaved renditions from different photos → accumulator correctly groups by `localIdentifier` regardless of render order.
+**Fix:** Replaced `collectRenditions` + `groupByPhoto` with inline per-rendition processing (see also fix #17, which completed this by removing an intermediate accumulator). Each rendition is uploaded and stacked immediately as it arrives, interleaving renders and uploads. `UploadHelpers.collectRenditions` and `groupByPhoto` had no remaining callers after this change and were removed.
 
 ---
 
@@ -214,32 +206,32 @@ The bug affected any same-extension pairing (JPG→JPG, TIF→TIF, PNG→PNG, et
 
 ---
 
-### 16. Insufficient INFO-level logging for upload, stack, and flow operations (multiple files)
+### 17. Insufficient INFO-level logging for upload, stack, and flow operations (multiple files)
 
-**Problem:** The plugin had only 3 INFO-level log statements across the entire codebase. Key operations — upload success, stack creation, and the original+export accumulator control flow — produced no INFO output. Diagnosing issues (such as the JPG→JPG stacking bug) required enabling TRACE and sifting through hundreds of low-level entries, or adding temporary code.
+**Problem:** The plugin had only 3 INFO-level log statements across the entire codebase. Key operations — upload success, stack creation, and export progress — produced no INFO output. Diagnosing issues (such as the JPG→JPG stacking bug) required enabling TRACE and sifting through hundreds of low-level entries, or adding temporary code.
 
 Specific gaps:
 
 - `uploadAsset` and `replaceAsset`: no log on success; could not confirm which `deviceAssetId` mapped to which Immich asset ID.
 - `createStack`: logged at TRACE on success; not visible without full TRACE output.
-- `processStackOriginalExportRenditions` accumulator: no log when a photo pair was flushed or an incomplete group was deferred to the single-rendition path.
 - `processOnePhotoGroup` / `processPublishOnePhotoGroup`: no log per upload or per stack attempt.
 - `processSingleRenditionRenditions` (`original_plus_jpeg_if_edited` path): no log for the original or export upload steps.
+- No export-start/done markers with config summary; no periodic progress logging.
 
 **Fix:** Added INFO-level logging to the following:
 
 - **ImmichAPI.lua `uploadAsset`**: logs `uploadAsset: <deviceAssetId> -> <assetId>` on success.
 - **ImmichAPI.lua `replaceAsset`**: logs `replaceAsset: <oldId> -> <newId>` on success; changed existing TRACE to INFO.
 - **ImmichAPI.lua `createStack`**: changed TRACE success log to INFO (`Stack created: <id> (N assets)`).
-- **ExportTask.lua / PublishTask.lua accumulator**: logs INFO when a photo pair is flushed (`flushing pair for <filename>`) and when an incomplete single-rendition group is deferred (`flushing incomplete group for <filename>`).
-- **ExportTask.lua / PublishTask.lua `processOnePhotoGroup` / `processPublishOnePhotoGroup`**: logs INFO per upload in `#items >= 2` path; logs INFO announcing single-rendition treatment in `#items == 1` path.
+- **ExportTask.lua / PublishTask.lua `processOnePhotoGroup` / `processPublishOnePhotoGroup`**: logs INFO per upload announcing role and `deviceAssetId → assetId` mapping.
 - **ExportTask.lua `processSingleRenditionRenditions`**: logs INFO when uploading the original and the edited export in the `original_plus_jpeg_if_edited` path.
+- **ExportTask.lua / PublishTask.lua `processRenderedPhotos`**: logs `=== Export START ===` / `=== Export DONE ===` with photo count, URL, and key settings; logs `Export progress: N/M (X%)` periodically.
 
-With logging enabled, a typical JPG→JPG export now produces clearly readable INFO entries showing the accumulator flush, each upload's `deviceAssetId → assetId` mapping, and the stack creation result.
+With logging enabled, a typical export now produces clearly readable INFO entries showing each upload's `deviceAssetId → assetId` mapping, stack creation results, and progress milestones.
 
 ---
 
-### 17. Progress bar advanced prematurely, appeared to go backwards, and disappeared before all uploads completed (ExportTask.lua, PublishTask.lua)
+### 18. Progress bar advanced prematurely, appeared to go backwards, and disappeared before all uploads completed (ExportTask.lua, PublishTask.lua)
 
 **Problem — premature completion (accumulator):** `processStackOriginalExportRenditions` and `processPublishStackOriginalExportRenditions` used an accumulator that flushed (uploaded) only when *two* renditions for the same photo had arrived (`#accumulator[lid] == 2`). Because `LR_exportOriginalFile` is never set, Lightroom always delivers exactly **one** rendition per photo, so the flush condition was never met during the main loop. All N renditions were rendered (filling the progress bar to 100%) before any upload began; then all uploads happened in a post-loop "flush incomplete groups" pass with the bar already full.
 
@@ -252,7 +244,7 @@ With logging enabled, a typical JPG→JPG export now produces clearly readable I
 
 ---
 
-### 18. Dead code: `generateBoundary`, `generateMultiPartBody`, `createHeadersForMultipartPut`, `doMultiPartPutRequest` (ImmichAPI.lua)
+### 19. Dead code: `generateBoundary`, `generateMultiPartBody`, `createHeadersForMultipartPut`, `doMultiPartPutRequest` (ImmichAPI.lua)
 
 **Problem:** These four functions were left over from an earlier implementation where `replaceAsset` issued a raw multipart PUT request by reading the entire file into memory (`fh:read("*all")`), building the request body as a Lua string, and calling `LrHttp.post` with `method = 'PUT'`. That path was replaced: `replaceAsset` now delegates to `uploadAsset`, which passes the file via `filePath` in the `postMultipart` content table so LR streams it from disk. The old functions had no remaining callers.
 
@@ -282,6 +274,6 @@ If any individual upload or stack creation fails, it is reported as a warning af
 | `PublishDialogSections.lua` | Section label and checkbox text updated, `stackOriginalExport` bind |
 | `ExportServiceProvider.lua` | `stackOriginalExport` preference key |
 | `PublishServiceProvider.lua` | `stackOriginalExport` preference key |
-| `ImmichAPI.lua` | Timeout increases, `HTTP_TIMEOUT_UPLOAD` wired into `postMultipart`, `table.concat` multipart body, explicit POST timeout, `handleRequestFailure` changed to log-only (no modal dialog), INFO logging for `uploadAsset`/`replaceAsset`/`createStack` success, removed dead `generateBoundary`/`generateMultiPartBody`/`createHeadersForMultipartPut`/`doMultiPartPutRequest` (no callers since `replaceAsset` was rewritten to delegate to `uploadAsset`) |
+| `ImmichAPI.lua` | Timeout increases, `HTTP_TIMEOUT_UPLOAD` wired into `postMultipart`, explicit POST timeout, `handleRequestFailure` changed to log-only (no modal dialog), INFO logging for `uploadAsset`/`replaceAsset`/`createStack` success, `replaceAsset` delegates to `uploadAsset` (LR streams file from disk via `filePath` in `postMultipart` — no in-memory file copy), removed dead `generateBoundary`/`generateMultiPartBody`/`createHeadersForMultipartPut`/`doMultiPartPutRequest` |
 | `StackManager.lua` | `hasEdits` cache short-circuit and comment fix, removed `getFileType` / `RAW_EXT` |
 | `UploadHelpers.lua` | `sortOriginalExportItems` with extension-based `isOriginal` flag and inverted `insertionOrder` tiebreaker (higher = rendered export = primary), removed `fileType` field, removed dead `collectRenditions`/`groupByPhoto`, updated comment |

--- a/PR.md
+++ b/PR.md
@@ -1,0 +1,151 @@
+# Pull Request: Fix original+export stacking, UI clarity, and reliability bugs
+
+## Summary
+
+This PR fixes the `original_plus_jpeg_if_edited` export mode (issue #91), corrects several bugs that caused duplicate uploads and wrong stack ordering, improves UI labeling, and addresses memory and timeout issues that caused failures on large exports.
+
+---
+
+## Bug fixes
+
+### 1. Stack primary image was wrong (ExportTask.lua)
+
+**Problem:** `createStack({ id, jpegId })` was called with the original file first. Immich uses the first element as the stack's key/cover image, so the unedited original was shown as the primary instead of the edited export.
+
+**Fix:** Swapped to `createStack({ jpegId, id })` so the rendered export is the primary in both `processOnePhotoGroup` and `processSingleRenditionRenditions`.
+
+---
+
+### 2. Album received the wrong asset (ExportTask.lua)
+
+**Problem:** After creating a stack, both code paths added the original (`id`) to the album and recorded it as the primary, even when the edited export (`jpegId`) was available.
+
+**Fix:** Introduced a `primaryId` variable that defaults to `id` and is updated to `jpegId` when the export upload succeeds. Album assignment and `exportedPrimaryByPhoto` now use `primaryId`.
+
+---
+
+### 3. "Original / no reformat" produced two identical uploads (ExportTask.lua, ExportDialogSections.lua)
+
+**Problem:** When Lightroom's export format is set to "Original / no reformat", Lightroom copies the source file byte-for-byte without rendering an edited version. The plugin then uploaded both copies as if they were distinct, resulting in two identical files in Immich with no meaningful stack.
+
+**Fix:**
+- Added a runtime guard in both `processOnePhotoGroup` and `processSingleRenditionRenditions`: if `LR_format == "ORIGINAL"`, skip the rendered export upload and emit a stack warning instead.
+- Added a live warning in the export dialog (orange text) when this incompatible combination is detected.
+- Detection uses `exportParams.LR_format` directly — no hardcoded format lists.
+
+---
+
+### 4. original+export stacking deviceAssetId was position-dependent (ExportTask.lua, PublishTask.lua)
+
+**Problem:** Device asset IDs for multi-rendition groups were generated as `lid_1`, `lid_2` based on loop position. If one rendition failed to render, subsequent files shifted positions and collided with previously uploaded asset IDs on retry, causing Immich's dedup check to match the wrong asset.
+
+**Fix:** Keyed by actual file extension (`lid_dng`, `lid_jpg`, `lid_tif`, etc.) using `util.getExtension(item.path)`. The ID is now stable regardless of rendering failures and agnostic to file format.
+
+---
+
+### 5. `checkIfAssetExists` used inconsistently (ExportTask.lua)
+
+**Problem:** The `original_only` / `original_plus_jpeg_if_edited` path in `processOnePhotoGroup` called the basic `checkIfAssetExists`, while `processSingleRenditionRenditions` called `checkIfAssetExistsEnhanced`. The enhanced version also checks stored Lightroom metadata (`immichAssetId`) and legacy `localIdentifier` uploads. This meant a photo previously exported via one path would not be recognised as already uploaded when re-exported via the other, creating duplicate assets.
+
+**Fix:** Changed the `processOnePhotoGroup` original path to use `checkIfAssetExistsEnhanced` consistently.
+
+---
+
+### 6. Upload timeout too low for large files (ImmichAPI.lua)
+
+**Problem:** `HTTP_TIMEOUT_UPLOAD` was 15 seconds. A 50 MB RAW file at 10 Mbps takes ~40 s; a 100 MB video at 5 Mbps takes ~160 s. Uploads that exceeded 15 s silently failed with no retry. `HTTP_TIMEOUT_DEFAULT` (5 s) was also applied to API calls like stacking and album operations that may legitimately take longer on slow servers.
+
+**Fix:** Increased `HTTP_TIMEOUT_UPLOAD` to 300 s (5 min) and `HTTP_TIMEOUT_DEFAULT` to 30 s. Also added an explicit timeout to `doPostRequest`, which previously relied on an undocumented LrHttp default.
+
+---
+
+### 7. High memory usage when replacing assets (ImmichAPI.lua)
+
+**Problem:** `generateMultiPartBody` built the multipart request body using repeated Lua string concatenation (`body = body .. chunk`). Lua strings are immutable, so each `..` allocated a new copy of all previous content. For a 50 MB RAW file this created ~100 MB of peak heap pressure just to build the request body.
+
+**Fix:** Accumulated body parts in a Lua table and called `table.concat(parts)` once at the end, performing a single allocation.
+
+---
+
+### 8. `hasEdits` ran redundant catalog queries when cache was present (StackManager.lua)
+
+**Problem:** When an `editedPhotosCache` was provided but the photo was not in it (meaning no edits), the function fell through to a fallback that ran two full `catalog:findPhotos` queries anyway — the same queries that were used to build the cache. For large catalogs this meant two extra full-catalog scans per unedited photo.
+
+**Fix:** When a cache is present it is now used exclusively. A cache miss immediately returns `false` without any fallback queries.
+
+---
+
+## UI improvements (ExportDialogSections.lua)
+
+- **Dropdown labels updated** to be format-agnostic:
+  - `"Always upload original only (no JPG)"` → `"Always upload original only (no export)"`
+  - `"Always upload original, JPG only if edited"` → `"Always upload original + rendered export (if edited)"`
+- **Section label** `"original+export export:"` → `"Original + Export:"` and checkbox `"Stack in Immich (edited JPG as primary)"` → `"Stack in Immich (export as primary)"` — the feature works with any export format, not just JPEG.
+- **Warning message** displayed in orange when "Original / no reformat" export format is selected alongside the "upload original + rendered export" mode, prompting the user to switch to JPEG or TIFF.
+
+---
+
+## Known limitations / not in this PR
+
+### collectRenditions batches all renders before upload starts (UploadHelpers.lua)
+
+For the original+export stacking path, `collectRenditions` waits for all renditions across the entire export batch to finish rendering before the first upload begins. On large exports this can fill temp disk before any files are cleaned up. The single-rendition path does not have this issue — it pipes render → upload → delete per photo.
+
+This was not fixed in this PR due to the scope of the required restructuring. Monitor temp disk usage during large original+export exports.
+
+#### Plan for future fix
+
+Replace `collectRenditions` in `processStackDngJpgRenditions` (ExportTask.lua) and `processPublishStackDngJpgRenditions` (PublishTask.lua) with an inline accumulator loop that flushes each photo group as soon as it is complete:
+
+```lua
+local accumulator = {}  -- lid -> { items }
+for _, rendition in exportContext:renditions { stopIfCanceled = true } do
+    if progressScope:isCanceled() then break end
+    local success, pathOrMessage = rendition:waitForRender()
+    if progressScope:isCanceled() then break end
+    if success then
+        local lid = rendition.photo.localIdentifier
+        if not accumulator[lid] then accumulator[lid] = {} end
+        table.insert(accumulator[lid], {
+            path = pathOrMessage,
+            photo = rendition.photo,
+            rendition = rendition,
+            ext = util.getExtension(pathOrMessage),
+            fileType = StackManager.getFileType(pathOrMessage),
+        })
+        -- Two renditions = group complete: upload and delete immediately
+        if #accumulator[lid] == 2 then
+            processOnePhotoGroup(immich, lid, accumulator[lid], ...)
+            accumulator[lid] = nil
+        end
+    end
+end
+-- Flush any remaining single-rendition groups (e.g. one rendition failed to render)
+for lid, items in pairs(accumulator) do
+    processOnePhotoGroup(immich, lid, items, ...)
+end
+```
+
+`processOnePhotoGroup` already handles the 1-item case so the end-of-loop flush requires no changes there. `UploadHelpers.collectRenditions` and `groupByPhoto` are no longer called from these paths but can remain for other uses.
+
+**Edge cases to test:** render failure on one of a pair (group flushes as single-item at end), cancellation mid-export (temp files from flushed groups are already deleted, only in-progress accumulator items remain), and interleaved renditions from different photos (accumulator handles this correctly regardless of order).
+
+### Upload timeout is configurable by editing ImmichAPI.lua
+
+`HTTP_TIMEOUT_UPLOAD` is now 300 s (5 min). If uploads still time out on very large files or slow connections, increase this value in `ImmichAPI.lua`. A future improvement would be to expose this as a plugin setting.
+
+### Stack warnings in the post-export dialog
+
+If any individual upload or stack creation fails, it is reported as a warning after export completes rather than aborting the entire run. Check the post-export dialog and the log file (`ImmichPlugin.log`) for `"failed to upload"` or `"failed to create stack"` entries.
+
+---
+
+## Files changed
+
+| File | Changes |
+|------|---------|
+| `ExportTask.lua` | Stack order fix, album primary fix, LR_format guard (×2), `checkIfAssetExistsEnhanced`, extension-based deviceAssetId |
+| `ExportDialogSections.lua` | Warning UI, updated dropdown labels, section label rename |
+| `ImmichAPI.lua` | Timeout increases, `table.concat` multipart body, explicit POST timeout |
+| `StackManager.lua` | `hasEdits` cache short-circuit |
+| `PublishTask.lua` | Extension-based deviceAssetId for original+export stacking |

--- a/immich-plugin.lrplugin/ExportDialogSections.lua
+++ b/immich-plugin.lrplugin/ExportDialogSections.lua
@@ -17,6 +17,16 @@ local function _updateCantExportBecause(propertyTable)
 	end)
 end
 
+local function _updateWarnings(propertyTable)
+    local mode = propertyTable.originalFileMode
+    local format = string.upper(propertyTable.LR_format or "")
+    if mode == 'original_plus_jpeg_if_edited' and format == "ORIGINAL" then
+        propertyTable.originalFormatWarning = "No reformat selected: switch to JPEG or TIFF to render edits."
+    else
+        propertyTable.originalFormatWarning = ""
+    end
+end
+
 local function _updateEditedPhotosCount(propertyTable)
     local mode = propertyTable.originalFileMode
     if mode ~= 'edited' and mode ~= 'original_plus_jpeg_if_edited' then
@@ -44,8 +54,9 @@ end
 -------------------------------------------------------------------------------
 
 function ExportDialogSections.startDialog(propertyTable)
-	-- Initialize edited photos count
+	-- Initialize edited photos count and format warning
 	propertyTable.editedPhotosCount = ""
+	propertyTable.originalFormatWarning = ""
 
 	LrTasks.startAsyncTask(function()
 		propertyTable.immich = ImmichAPI:new(propertyTable.url, propertyTable.apiKey)
@@ -54,13 +65,20 @@ function ExportDialogSections.startDialog(propertyTable)
 	end)
 	-- propertyTable:addObserver('url', _updateCantExportBecause)
 	-- propertyTable:addObserver('apiKey', _updateCantExportBecause)
-	
+
 	-- Add observer for originalFileMode changes
 	propertyTable:addObserver('originalFileMode', function(key, value)
+		_updateWarnings(propertyTable)
 		_updateEditedPhotosCount(propertyTable)
 	end)
-	
-	-- Trigger initial count if mode uses edit detection
+
+	-- Add observer for LR_format changes (catches "Original / no reformat" selection)
+	propertyTable:addObserver('LR_format', function(key, value)
+		_updateWarnings(propertyTable)
+	end)
+
+	-- Trigger initial state
+	_updateWarnings(propertyTable)
 	if propertyTable.originalFileMode == 'edited' or propertyTable.originalFileMode == 'original_plus_jpeg_if_edited' then
 		-- Small delay to ensure UI is ready
 		LrTasks.startAsyncTask(function()
@@ -111,8 +129,8 @@ function ExportDialogSections.sectionsForBottomOfDialog(f, propertyTable)
 							{ title = "Don't upload original files", value = 'none' },
 							{ title = "Upload originals for edited photos only", value = 'edited' },
 							{ title = "Upload originals for all photos", value = 'all' },
-							{ title = "Always upload original only (no JPG)", value = 'original_only' },
-							{ title = "Always upload original, JPG only if edited", value = 'original_plus_jpeg_if_edited' },
+							{ title = "Always upload original only (no export)", value = 'original_only' },
+							{ title = "Always upload original + rendered export (if edited)", value = 'original_plus_jpeg_if_edited' },
 						},
 						value = bind 'originalFileMode'
 					},
@@ -133,12 +151,26 @@ function ExportDialogSections.sectionsForBottomOfDialog(f, propertyTable)
 				},
 				f:row {
 					f:static_text {
-						title = "DNG+JPG export:",
+						title = "",
+						alignment = 'right',
+						width = LrView.share "label_width",
+					},
+					f:static_text {
+						title = bind 'originalFormatWarning',
+						alignment = 'left',
+						fill_horizontal = 1,
+						font = '<system/small>',
+						text_color = LrColor(0.8, 0.3, 0.0),
+					},
+				},
+				f:row {
+					f:static_text {
+						title = "Original + Export:",
 						alignment = 'right',
 						width = LrView.share "label_width",
 					},
 					f:checkbox {
-						title = "Stack in Immich (edited JPG as primary)",
+						title = "Stack in Immich (export as primary)",
 						value = bind 'stackDngJpg',
 					},
 				},

--- a/immich-plugin.lrplugin/ExportDialogSections.lua
+++ b/immich-plugin.lrplugin/ExportDialogSections.lua
@@ -21,7 +21,7 @@ local function _updateWarnings(propertyTable)
     local mode = propertyTable.originalFileMode
     local format = string.upper(propertyTable.LR_format or "")
     if mode == 'original_plus_jpeg_if_edited' and format == "ORIGINAL" then
-        propertyTable.originalFormatWarning = "No reformat selected: switch to JPEG or TIFF to render edits."
+        propertyTable.originalFormatWarning = "No reformat selected: switch to any rendered format (e.g. JPEG, TIFF, PNG) to render edits."
     else
         propertyTable.originalFormatWarning = ""
     end

--- a/immich-plugin.lrplugin/ExportDialogSections.lua
+++ b/immich-plugin.lrplugin/ExportDialogSections.lua
@@ -171,7 +171,7 @@ function ExportDialogSections.sectionsForBottomOfDialog(f, propertyTable)
 					},
 					f:checkbox {
 						title = "Stack in Immich (export as primary)",
-						value = bind 'stackDngJpg',
+						value = bind 'stackOriginalExport',
 					},
 				},
 				f:row {

--- a/immich-plugin.lrplugin/ExportDialogSections.lua
+++ b/immich-plugin.lrplugin/ExportDialogSections.lua
@@ -20,8 +20,8 @@ end
 local function _updateWarnings(propertyTable)
     local mode = propertyTable.originalFileMode
     local format = string.upper(propertyTable.LR_format or "")
-    if mode == 'original_plus_jpeg_if_edited' and format == "ORIGINAL" then
-        propertyTable.originalFormatWarning = "No reformat selected: switch to any rendered format (e.g. JPEG, TIFF, PNG) to render edits."
+    if format == "ORIGINAL" and (mode == 'original_plus_jpeg_if_edited' or propertyTable.stackOriginalExport) then
+        propertyTable.originalFormatWarning = "No reformat selected: switch to any rendered format (e.g. JPEG, TIFF, PNG) to produce a distinct export for stacking."
     else
         propertyTable.originalFormatWarning = ""
     end
@@ -74,6 +74,11 @@ function ExportDialogSections.startDialog(propertyTable)
 
 	-- Add observer for LR_format changes (catches "Original / no reformat" selection)
 	propertyTable:addObserver('LR_format', function(key, value)
+		_updateWarnings(propertyTable)
+	end)
+
+	-- Add observer for stackOriginalExport changes (warn when ORIGINAL format + stacking enabled)
+	propertyTable:addObserver('stackOriginalExport', function(key, value)
 		_updateWarnings(propertyTable)
 	end)
 

--- a/immich-plugin.lrplugin/ExportServiceProvider.lua
+++ b/immich-plugin.lrplugin/ExportServiceProvider.lua
@@ -15,7 +15,7 @@ return {
 		{ key = 'album',     default = nil },
 		{ key = 'albumMode', default = 'none' },
 		{ key = 'originalFileMode', default = 'none' },
-		{ key = 'stackDngJpg', default = false },
+		{ key = 'stackOriginalExport', default = false },
 		{ key = 'stackLrStacks', default = false },
 	},
 

--- a/immich-plugin.lrplugin/ExportTask.lua
+++ b/immich-plugin.lrplugin/ExportTask.lua
@@ -187,8 +187,9 @@ local function processOnePhotoGroup(immich, lid, items, exportParams, albumId, u
         local primaryId = nil
         for i, item in ipairs(items) do
             -- After sort: items[1]=export (primary), items[2]=original.
-            -- Index-based suffix guarantees distinct IDs regardless of format pairing.
-            local deviceAssetId = lid .. (i == 1 and "_export" or "_orig")
+            -- Suffix is stable for the expected two-item pair; extra renditions get an index suffix.
+            local suffix = (i == 1) and "_export" or (i == 2) and "_orig" or ("_rend" .. tostring(i))
+            local deviceAssetId = lid .. suffix
             local id = StackManager.uploadOneAssetOrReplace(immich, item.path, deviceAssetId, filename, dateCreated)
             UploadHelpers.safeDeleteTempFile(item.path)
             if not id then
@@ -384,12 +385,13 @@ local function processSingleRenditionRenditions(immich, exportContext, progressS
                 end
                 UploadHelpers.safeDeleteTempFile(pathOrMessage)
             end
-            done = done + 1
-            progressScope:setPortionComplete(done, nPhotos)
-            if done == 1 or done % 10 == 0 or done == nPhotos then
-                log:info('Export progress: ' .. done .. '/' .. nPhotos
-                    .. ' (' .. math.floor(done * 100 / nPhotos) .. '%)')
-            end
+        end
+        -- Advance progress for every rendition, including failed renders, so the bar reaches 100%.
+        done = done + 1
+        progressScope:setPortionComplete(done, nPhotos)
+        if done == 1 or done % 10 == 0 or done == nPhotos then
+            log:info('Export progress: ' .. done .. '/' .. nPhotos
+                .. ' (' .. math.floor(done * 100 / nPhotos) .. '%)')
         end
     end
     return failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto

--- a/immich-plugin.lrplugin/ExportTask.lua
+++ b/immich-plugin.lrplugin/ExportTask.lua
@@ -248,7 +248,7 @@ local function processOnePhotoGroup(immich, lid, items, exportParams, albumId, u
                 -- Original copy arrived; export did not render or is not expected in this mode/format.
                 if exportParams.originalFileMode == "original_plus_jpeg_if_edited" and StackManager.hasEdits(photo, editedPhotosCache) then
                     if string.upper(exportParams.LR_format or "") == "ORIGINAL" then
-                        table.insert(stackWarnings, filename .. ": skipped rendered export — 'Original / no reformat' does not produce an edited version. Change export format to JPEG or TIFF.")
+                        table.insert(stackWarnings, filename .. ": skipped rendered export — 'Original / no reformat' does not produce an edited version. Switch to any rendered format (e.g. JPEG, TIFF, PNG).")
                     else
                         table.insert(stackWarnings, filename .. ": rendered export did not arrive; uploaded original only")
                     end
@@ -339,7 +339,7 @@ local function processSingleRenditionRenditions(immich, exportContext, progressS
                         local primaryId = id
                         if originalFileMode == 'original_plus_jpeg_if_edited' and StackManager.hasEdits(photo, editedPhotosCache) then
                             if string.upper(exportParams.LR_format or "") == "ORIGINAL" then
-                                table.insert(stackWarnings, photo:getFormattedMetadata("fileName") .. ": skipped rendered export — 'Original / no reformat' does not produce an edited version. Change export format to JPEG or TIFF.")
+                                table.insert(stackWarnings, photo:getFormattedMetadata("fileName") .. ": skipped rendered export — 'Original / no reformat' does not produce an edited version. Switch to any rendered format (e.g. JPEG, TIFF, PNG).")
                             else
                                 local deviceAssetIdEdited = tostring(deviceAssetId) .. "_edited"
                                 local fileName, dateCreated = photo:getFormattedMetadata("fileName"), photo:getFormattedMetadata("dateCreated")

--- a/immich-plugin.lrplugin/ExportTask.lua
+++ b/immich-plugin.lrplugin/ExportTask.lua
@@ -197,6 +197,7 @@ local function processOnePhotoGroup(immich, lid, items, exportParams, albumId, u
                 atLeastSomeSuccess[1] = true
                 table.insert(assetIds, id)
                 if primaryId == nil then primaryId = id end
+                log:info('original+export [' .. filename .. ']: ' .. deviceAssetId .. ' -> ' .. id)
             end
         end
         if #assetIds >= 2 and primaryId then
@@ -217,11 +218,14 @@ local function processOnePhotoGroup(immich, lid, items, exportParams, albumId, u
             -- original under a different deviceAssetId and create a duplicate stack.
         end
     elseif #items == 1 then
-        -- One rendition arrived (the other failed to render or was not expected for this photo/mode).
-        -- Use isOriginal to determine the role: original copy (_orig) vs rendered export (_export).
+        -- One rendition arrived. Since LR_exportOriginalFile is never set, Lightroom always
+        -- delivers the rendered export (never an original-copy rendition). The isOriginal flag
+        -- is a false positive for same-extension pairs (e.g. JPG→JPG, TIF→TIF): the rendered
+        -- export and the source share the same extension, but the rendition is still the edited
+        -- export. Always treat the single rendition as the export and fetch the disk original.
         local item = items[1]
-        local isOrig = item.isOriginal == true
-        local deviceAssetId = lid .. (isOrig and "_orig" or "_export")
+        local deviceAssetId = lid .. "_export"
+        log:info('original+export [' .. filename .. ']: single rendition, uploading as export (' .. deviceAssetId .. ')')
         local id = StackManager.uploadOneAssetOrReplace(immich, item.path, deviceAssetId, filename, dateCreated)
         UploadHelpers.safeDeleteTempFile(item.path)
         if not id then
@@ -229,30 +233,18 @@ local function processOnePhotoGroup(immich, lid, items, exportParams, albumId, u
         else
             atLeastSomeSuccess[1] = true
             local primaryId = id
-            if not isOrig then
-                -- Export rendition arrived; upload disk original and create stack.
-                local originalPath = StackManager.getOriginalFilePath(photo)
-                if originalPath then
-                    local origId = StackManager.uploadOneAssetOrReplace(immich, originalPath, lid .. "_orig", filename, dateCreated)
-                    if origId then
-                        if not immich:createStack({ id, origId }) then
-                            table.insert(stackWarnings, filename .. ": failed to create original+export stack")
-                        end
-                    else
-                        table.insert(stackWarnings, filename .. ": failed to upload original file")
+            local originalPath = StackManager.getOriginalFilePath(photo)
+            if originalPath then
+                local origId = StackManager.uploadOneAssetOrReplace(immich, originalPath, lid .. "_orig", filename, dateCreated)
+                if origId then
+                    if not immich:createStack({ id, origId }) then
+                        table.insert(stackWarnings, filename .. ": failed to create original+export stack")
                     end
                 else
-                    table.insert(stackWarnings, filename .. ": original file not accessible; uploaded export only")
+                    table.insert(stackWarnings, filename .. ": failed to upload original file")
                 end
             else
-                -- Original copy arrived; export did not render or is not expected in this mode/format.
-                if exportParams.originalFileMode == "original_plus_jpeg_if_edited" and StackManager.hasEdits(photo, editedPhotosCache) then
-                    if string.upper(exportParams.LR_format or "") == "ORIGINAL" then
-                        table.insert(stackWarnings, filename .. ": skipped rendered export — 'Original / no reformat' does not produce an edited version. Switch to any rendered format (e.g. JPEG, TIFF, PNG).")
-                    else
-                        table.insert(stackWarnings, filename .. ": rendered export did not arrive; uploaded original only")
-                    end
-                end
+                table.insert(stackWarnings, filename .. ": original file not accessible; uploaded export only")
             end
             exportedPrimaryByPhoto[photo.localIdentifier] = { assetId = primaryId, photo = photo }
             if useAlbum then immich:addAssetToAlbum(albumId, primaryId)
@@ -265,13 +257,16 @@ local function processOnePhotoGroup(immich, lid, items, exportParams, albumId, u
 end
 
 --------------------------------------------------------------------------------
--- Original+export flow: accumulate renditions per photo, flush each group as soon as
--- both renditions are ready. This avoids buffering all renders before any upload starts.
-local function processStackOriginalExportRenditions(immich, exportContext, progressScope, exportParams, albumId, useAlbum, editedPhotosCache)
+-- Original+export flow: process each rendition immediately as it arrives, keeping
+-- renders and uploads interleaved so the Lightroom progress bar advances
+-- proportionally to real work done. LR_exportOriginalFile is never set, so LR
+-- always delivers exactly one rendition per photo; the disk original is fetched
+-- inside processOnePhotoGroup.
+local function processStackOriginalExportRenditions(immich, exportContext, progressScope, nPhotos, exportParams, albumId, useAlbum, editedPhotosCache)
     local failures, stackWarnings = {}, {}
     local atLeastSomeSuccess = { false }
     local exportedPrimaryByPhoto = {}
-    local accumulator = {}
+    local done = 0
     for _, rendition in exportContext:renditions { stopIfCanceled = true } do
         if progressScope:isCanceled() then break end
         local success, pathOrMessage = rendition:waitForRender()
@@ -279,31 +274,25 @@ local function processStackOriginalExportRenditions(immich, exportContext, progr
         if success then
             -- Use stable device ID (UUID when available) so deviceAssetIds survive catalog re-imports.
             local lid = util.getPhotoDeviceId(rendition.photo) or rendition.photo.localIdentifier
-            if not accumulator[lid] then accumulator[lid] = {} end
             local srcPath = StackManager.getOriginalFilePath(rendition.photo)
             local srcExt = srcPath and util.getExtension(srcPath) or ""
             local itemExt = util.getExtension(pathOrMessage)
-            table.insert(accumulator[lid], {
+            local item = {
                 path = pathOrMessage,
                 photo = rendition.photo,
                 rendition = rendition,
                 ext = itemExt,
                 isOriginal = srcExt ~= "" and itemExt == srcExt,
-                insertionOrder = #accumulator[lid],  -- 0-based; used as stable sort tiebreaker
-            })
-            -- Both renditions for this photo are ready: upload and stack immediately.
-            if #accumulator[lid] == 2 then
-                processOnePhotoGroup(immich, lid, accumulator[lid], exportParams, albumId, useAlbum, editedPhotosCache,
-                    failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto)
-                accumulator[lid] = nil
-            end
-        end
-    end
-    -- Flush any incomplete groups (one rendition failed to render or export was canceled).
-    for lid, items in pairs(accumulator) do
-        if not progressScope:isCanceled() then
-            processOnePhotoGroup(immich, lid, items, exportParams, albumId, useAlbum, editedPhotosCache,
+                insertionOrder = 0,
+            }
+            processOnePhotoGroup(immich, lid, { item }, exportParams, albumId, useAlbum, editedPhotosCache,
                 failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto)
+            done = done + 1
+            progressScope:setPortionComplete(done, nPhotos)
+            if done == 1 or done % 10 == 0 or done == nPhotos then
+                log:info('Export progress: ' .. done .. '/' .. nPhotos
+                    .. ' (' .. math.floor(done * 100 / nPhotos) .. '%)')
+            end
         end
     end
     return failures, stackWarnings, atLeastSomeSuccess[1], exportedPrimaryByPhoto
@@ -311,10 +300,11 @@ end
 
 --------------------------------------------------------------------------------
 -- Single-rendition flow: one loop over renditions.
-local function processSingleRenditionRenditions(immich, exportContext, progressScope, exportParams, albumId, useAlbum, editedPhotosCache)
+local function processSingleRenditionRenditions(immich, exportContext, progressScope, nPhotos, exportParams, albumId, useAlbum, editedPhotosCache)
     local failures, stackWarnings = {}, {}
     local atLeastSomeSuccess = false
     local exportedPrimaryByPhoto = {}
+    local done = 0
     for _, rendition in exportContext:renditions { stopIfCanceled = true } do
         local success, pathOrMessage = rendition:waitForRender()
         if progressScope:isCanceled() then break end
@@ -330,6 +320,7 @@ local function processSingleRenditionRenditions(immich, exportContext, progressS
                 else
                     local existingId, existingDeviceId = immich:checkIfAssetExistsEnhanced(photo, deviceAssetId,
                         photo:getFormattedMetadata("fileName"), photo:getFormattedMetadata("dateCreated"))
+                    log:info('single-rendition [' .. photo:getFormattedMetadata("fileName") .. ']: uploading original (' .. tostring(deviceAssetId) .. ')')
                     local id = (existingId == nil) and immich:uploadAsset(originalPath, deviceAssetId)
                         or immich:replaceAsset(existingId, originalPath, existingDeviceId or deviceAssetId)
                     if not id then
@@ -343,6 +334,7 @@ local function processSingleRenditionRenditions(immich, exportContext, progressS
                             else
                                 local deviceAssetIdEdited = tostring(deviceAssetId) .. "_edited"
                                 local fileName, dateCreated = photo:getFormattedMetadata("fileName"), photo:getFormattedMetadata("dateCreated")
+                                log:info('single-rendition [' .. fileName .. ']: uploading edited export (' .. deviceAssetIdEdited .. ')')
                                 local existingExportId, existingExportDeviceId = immich:checkIfAssetExists(deviceAssetIdEdited, fileName, dateCreated)
                                 local exportId
                                 if existingExportId then
@@ -396,6 +388,12 @@ local function processSingleRenditionRenditions(immich, exportContext, progressS
                 end
                 UploadHelpers.safeDeleteTempFile(pathOrMessage)
             end
+            done = done + 1
+            progressScope:setPortionComplete(done, nPhotos)
+            if done == 1 or done % 10 == 0 or done == nPhotos then
+                log:info('Export progress: ' .. done .. '/' .. nPhotos
+                    .. ' (' .. math.floor(done * 100 / nPhotos) .. '%)')
+            end
         end
     end
     return failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto
@@ -403,14 +401,14 @@ end
 
 --------------------------------------------------------------------------------
 -- Run the appropriate export path and apply LR stacks; return result tables.
-local function runExport(immich, exportContext, progressScope, exportParams, albumId, useAlbum, editedPhotosCache)
+local function runExport(immich, exportContext, progressScope, nPhotos, exportParams, albumId, useAlbum, editedPhotosCache)
     local failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto
     if exportParams.stackOriginalExport then
         failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto = processStackOriginalExportRenditions(
-            immich, exportContext, progressScope, exportParams, albumId, useAlbum, editedPhotosCache)
+            immich, exportContext, progressScope, nPhotos, exportParams, albumId, useAlbum, editedPhotosCache)
     else
         failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto = processSingleRenditionRenditions(
-            immich, exportContext, progressScope, exportParams, albumId, useAlbum, editedPhotosCache)
+            immich, exportContext, progressScope, nPhotos, exportParams, albumId, useAlbum, editedPhotosCache)
     end
     if exportParams.stackLrStacks and next(exportedPrimaryByPhoto) then
         UploadHelpers.applyLrStacksInImmich(immich, exportedPrimaryByPhoto, stackWarnings)
@@ -436,8 +434,20 @@ function ExportTask.processRenderedPhotos(functionContext, exportContext)
     if not exportSession or not exportParams then return nil end
 
     local nPhotos = exportSession:countRenditions()
-    local progressScope = exportContext:configureProgress {
-        title = buildProgressTitle(nPhotos, exportParams.originalFileMode, exportParams.url or "")
+    log:info('=== Export START: ' .. nPhotos .. ' photos | url=' .. tostring(exportParams.url)
+        .. ' | originalFileMode=' .. tostring(exportParams.originalFileMode)
+        .. ' | stackOriginalExport=' .. tostring(exportParams.stackOriginalExport)
+        .. ' | stackLrStacks=' .. tostring(exportParams.stackLrStacks)
+        .. ' | albumMode=' .. tostring(exportParams.albumMode) .. ' ===')
+
+    -- Use LrProgressScope tied to functionContext rather than exportContext:configureProgress.
+    -- configureProgress creates a scope managed by LR's render pipeline, which closes the bar
+    -- when rendering completes — potentially long before all uploads are done. LrProgressScope
+    -- with functionContext stays alive until processRenderedPhotos returns, and is not advanced
+    -- by LR's render thread, eliminating both early-close and forward→0→return race conditions.
+    local progressScope = LrProgressScope {
+        title = buildProgressTitle(nPhotos, exportParams.originalFileMode, exportParams.url or ""),
+        functionContext = functionContext,
     }
 
     local canceled, albumId, useAlbum = resolveAlbumForExport(immich, exportParams)
@@ -446,7 +456,9 @@ function ExportTask.processRenderedPhotos(functionContext, exportContext)
     local editedPhotosCache = getEditedPhotosCacheIfNeeded(exportParams)
 
     local failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto = runExport(
-        immich, exportContext, progressScope, exportParams, albumId, useAlbum, editedPhotosCache)
+        immich, exportContext, progressScope, nPhotos, exportParams, albumId, useAlbum, editedPhotosCache)
 
+    log:info('=== Export DONE: ' .. nPhotos .. ' photos | failures=' .. #failures
+        .. ' | warnings=' .. #stackWarnings .. ' ===')
     finalizeExport(immich, exportParams, albumId, useAlbum, atLeastSomeSuccess, failures, stackWarnings)
 end

--- a/immich-plugin.lrplugin/ExportTask.lua
+++ b/immich-plugin.lrplugin/ExportTask.lua
@@ -107,7 +107,7 @@ local function buildProgressTitle(nPhotos, originalFileMode, url)
         if originalFileMode == 'edited' then modeText = " (with originals for edited)"
         elseif originalFileMode == 'all' then modeText = " (with originals for all)"
         elseif originalFileMode == 'original_only' then modeText = " (original only)"
-        elseif originalFileMode == 'original_plus_jpeg_if_edited' then modeText = " (original + JPG if edited)"
+        elseif originalFileMode == 'original_plus_jpeg_if_edited' then modeText = " (original + export if edited)"
         end
     end
     local countStr = (nPhotos > 1) and (nPhotos .. " photos") or "one photo"
@@ -174,22 +174,15 @@ local function getEditedPhotosCacheIfNeeded(exportParams)
 end
 
 --------------------------------------------------------------------------------
--- Process one photo group (DNG+JPG flow). Mutates state tables; returns nothing.
+-- Process one photo group (original+export flow). Mutates state tables; returns nothing.
 local function processOnePhotoGroup(immich, lid, items, exportParams, albumId, useAlbum, editedPhotosCache,
     failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto)
     if not items or not items[1] then return end
     local photo = items[1].photo
     local filename = photo:getFormattedMetadata("fileName")
     local dateCreated = photo:getFormattedMetadata("dateCreated")
-    local hasRaw, hasJpeg = false, false
-    for _, item in ipairs(items) do
-        if item.fileType == "raw" then hasRaw = true end
-        if item.fileType == "jpeg" then hasJpeg = true end
-    end
-    local shouldStackDngJpg = hasRaw and hasJpeg
-
-    if shouldStackDngJpg and #items >= 2 then
-        UploadHelpers.sortDngJpgItems(items)
+    if #items >= 2 then
+        UploadHelpers.sortOriginalExportItems(items)
         local assetIds = {}
         local primaryId = nil
         for _, item in ipairs(items) do
@@ -206,7 +199,7 @@ local function processOnePhotoGroup(immich, lid, items, exportParams, albumId, u
         end
         if #assetIds >= 2 and primaryId then
             if not immich:createStack(assetIds) then
-                table.insert(stackWarnings, filename .. ": Failed to create DNG+JPG stack")
+                table.insert(stackWarnings, filename .. ": Failed to create original+export stack")
             end
         end
         if primaryId then
@@ -250,18 +243,20 @@ local function processOnePhotoGroup(immich, lid, items, exportParams, albumId, u
                         table.insert(stackWarnings, filename .. ": skipped rendered export — 'Original / no reformat' does not produce an edited version. Change export format to JPEG or TIFF.")
                     else
                         local deviceAssetIdEdited = tostring(deviceAssetId) .. "_edited"
-                        local existingJpegId, existingJpegDeviceId = immich:checkIfAssetExists(deviceAssetIdEdited, filename, dateCreated)
-                        local jpegId
-                        if existingJpegId then
-                            jpegId = immich:replaceAsset(existingJpegId, items[1].path, existingJpegDeviceId or deviceAssetIdEdited)
+                        local existingExportId, existingExportDeviceId = immich:checkIfAssetExists(deviceAssetIdEdited, filename, dateCreated)
+                        local exportId
+                        if existingExportId then
+                            exportId = immich:replaceAsset(existingExportId, items[1].path, existingExportDeviceId or deviceAssetIdEdited)
                         else
-                            jpegId = immich:uploadAsset(items[1].path, deviceAssetIdEdited)
+                            exportId = immich:uploadAsset(items[1].path, deviceAssetIdEdited)
                         end
-                        if jpegId then
-                            primaryId = jpegId
-                            if not immich:createStack({ jpegId, id }) then
+                        if exportId then
+                            primaryId = exportId
+                            if not immich:createStack({ exportId, id }) then
                                 table.insert(stackWarnings, filename .. ": Failed to create stack")
                             end
+                        else
+                            table.insert(stackWarnings, filename .. ": failed to upload rendered export")
                         end
                     end
                 end
@@ -307,18 +302,40 @@ local function processOnePhotoGroup(immich, lid, items, exportParams, albumId, u
 end
 
 --------------------------------------------------------------------------------
--- DNG+JPG flow: collect, group by photo, process each group.
-local function processStackDngJpgRenditions(immich, exportContext, progressScope, exportParams, albumId, useAlbum, editedPhotosCache)
+-- Original+export flow: accumulate renditions per photo, flush each group as soon as
+-- both renditions are ready. This avoids buffering all renders before any upload starts.
+local function processStackOriginalExportRenditions(immich, exportContext, progressScope, exportParams, albumId, useAlbum, editedPhotosCache)
     local failures, stackWarnings = {}, {}
     local atLeastSomeSuccess = { false }
     local exportedPrimaryByPhoto = {}
-    local collected = UploadHelpers.collectRenditions(exportContext, progressScope)
-    if not collected then return failures, stackWarnings, atLeastSomeSuccess[1], exportedPrimaryByPhoto end
-    local byPhoto = UploadHelpers.groupByPhoto(collected)
-    for lid, items in pairs(byPhoto) do
+    local accumulator = {}
+    for _, rendition in exportContext:renditions { stopIfCanceled = true } do
         if progressScope:isCanceled() then break end
-        processOnePhotoGroup(immich, lid, items, exportParams, albumId, useAlbum, editedPhotosCache,
-            failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto)
+        local success, pathOrMessage = rendition:waitForRender()
+        if progressScope:isCanceled() then break end
+        if success then
+            local lid = rendition.photo.localIdentifier
+            if not accumulator[lid] then accumulator[lid] = {} end
+            table.insert(accumulator[lid], {
+                path = pathOrMessage,
+                photo = rendition.photo,
+                rendition = rendition,
+                ext = util.getExtension(pathOrMessage),
+            })
+            -- Both renditions for this photo are ready: upload and stack immediately.
+            if #accumulator[lid] == 2 then
+                processOnePhotoGroup(immich, lid, accumulator[lid], exportParams, albumId, useAlbum, editedPhotosCache,
+                    failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto)
+                accumulator[lid] = nil
+            end
+        end
+    end
+    -- Flush any incomplete groups (one rendition failed to render or export was canceled).
+    for lid, items in pairs(accumulator) do
+        if not progressScope:isCanceled() then
+            processOnePhotoGroup(immich, lid, items, exportParams, albumId, useAlbum, editedPhotosCache,
+                failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto)
+        end
     end
     return failures, stackWarnings, atLeastSomeSuccess[1], exportedPrimaryByPhoto
 end
@@ -357,20 +374,20 @@ local function processSingleRenditionRenditions(immich, exportContext, progressS
                             else
                                 local deviceAssetIdEdited = tostring(deviceAssetId) .. "_edited"
                                 local fileName, dateCreated = photo:getFormattedMetadata("fileName"), photo:getFormattedMetadata("dateCreated")
-                                local existingJpegId, existingJpegDeviceId = immich:checkIfAssetExists(deviceAssetIdEdited, fileName, dateCreated)
-                                local jpegId
-                                if existingJpegId then
-                                    jpegId = immich:replaceAsset(existingJpegId, pathOrMessage, existingJpegDeviceId or deviceAssetIdEdited)
+                                local existingExportId, existingExportDeviceId = immich:checkIfAssetExists(deviceAssetIdEdited, fileName, dateCreated)
+                                local exportId
+                                if existingExportId then
+                                    exportId = immich:replaceAsset(existingExportId, pathOrMessage, existingExportDeviceId or deviceAssetIdEdited)
                                 else
-                                    jpegId = immich:uploadAsset(pathOrMessage, deviceAssetIdEdited)
+                                    exportId = immich:uploadAsset(pathOrMessage, deviceAssetIdEdited)
                                 end
-                                if jpegId then
-                                    primaryId = jpegId
-                                    if not immich:createStack({ jpegId, id }) then
+                                if exportId then
+                                    primaryId = exportId
+                                    if not immich:createStack({ exportId, id }) then
                                         table.insert(stackWarnings, photo:getFormattedMetadata("fileName") .. ": failed to create stack")
                                     end
                                 else
-                                    table.insert(stackWarnings, photo:getFormattedMetadata("fileName") .. ": failed to upload JPG")
+                                    table.insert(stackWarnings, photo:getFormattedMetadata("fileName") .. ": failed to upload rendered export")
                                 end
                             end
                         end
@@ -419,8 +436,8 @@ end
 -- Run the appropriate export path and apply LR stacks; return result tables.
 local function runExport(immich, exportContext, progressScope, exportParams, albumId, useAlbum, editedPhotosCache)
     local failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto
-    if exportParams.stackDngJpg then
-        failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto = processStackDngJpgRenditions(
+    if exportParams.stackOriginalExport then
+        failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto = processStackOriginalExportRenditions(
             immich, exportContext, progressScope, exportParams, albumId, useAlbum, editedPhotosCache)
     else
         failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto = processSingleRenditionRenditions(
@@ -434,7 +451,7 @@ end
 
 --------------------------------------------------------------------------------
 local function finalizeExport(immich, exportParams, albumId, useAlbum, atLeastSomeSuccess, failures, stackWarnings)
-    -- Use explicit true check so we behave correctly whether we receive a boolean or (if ever) the DNG+JPG table reference.
+    -- Use explicit true check so we behave correctly whether we receive a boolean or a table reference.
     local anySuccess = atLeastSomeSuccess == true or (type(atLeastSomeSuccess) == "table" and atLeastSomeSuccess[1] == true)
     if not anySuccess and exportParams.albumMode == 'new' and albumId then
         log:trace('Deleting newly created album, as no upload succeeded, and album would remain as orphan.')

--- a/immich-plugin.lrplugin/ExportTask.lua
+++ b/immich-plugin.lrplugin/ExportTask.lua
@@ -219,10 +219,8 @@ local function processOnePhotoGroup(immich, lid, items, exportParams, albumId, u
         end
     elseif #items == 1 then
         -- One rendition arrived. Since LR_exportOriginalFile is never set, Lightroom always
-        -- delivers the rendered export (never an original-copy rendition). The isOriginal flag
-        -- is a false positive for same-extension pairs (e.g. JPG→JPG, TIF→TIF): the rendered
-        -- export and the source share the same extension, but the rendition is still the edited
-        -- export. Always treat the single rendition as the export and fetch the disk original.
+        -- delivers the rendered export (never an original-copy rendition), so item.role = "export".
+        -- Always treat the single rendition as the export and fetch the disk original.
         local item = items[1]
         local deviceAssetId = lid .. "_export"
         log:info('original+export [' .. filename .. ']: single rendition, uploading as export (' .. deviceAssetId .. ')')
@@ -274,25 +272,23 @@ local function processStackOriginalExportRenditions(immich, exportContext, progr
         if success then
             -- Use stable device ID (UUID when available) so deviceAssetIds survive catalog re-imports.
             local lid = util.getPhotoDeviceId(rendition.photo) or rendition.photo.localIdentifier
-            local srcPath = StackManager.getOriginalFilePath(rendition.photo)
-            local srcExt = srcPath and util.getExtension(srcPath) or ""
-            local itemExt = util.getExtension(pathOrMessage)
+            -- role = "export": LR_exportOriginalFile is never set, so LR always delivers the
+            -- rendered export (never an original-copy rendition), regardless of file extension.
             local item = {
                 path = pathOrMessage,
                 photo = rendition.photo,
                 rendition = rendition,
-                ext = itemExt,
-                isOriginal = srcExt ~= "" and itemExt == srcExt,
-                insertionOrder = 0,
+                role = "export",
             }
             processOnePhotoGroup(immich, lid, { item }, exportParams, albumId, useAlbum, editedPhotosCache,
                 failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto)
-            done = done + 1
-            progressScope:setPortionComplete(done, nPhotos)
-            if done == 1 or done % 10 == 0 or done == nPhotos then
-                log:info('Export progress: ' .. done .. '/' .. nPhotos
-                    .. ' (' .. math.floor(done * 100 / nPhotos) .. '%)')
-            end
+        end
+        -- Advance progress for every rendition, including failed renders, so the bar reaches 100%.
+        done = done + 1
+        progressScope:setPortionComplete(done, nPhotos)
+        if done == 1 or done % 10 == 0 or done == nPhotos then
+            log:info('Export progress: ' .. done .. '/' .. nPhotos
+                .. ' (' .. math.floor(done * 100 / nPhotos) .. '%)')
         end
     end
     return failures, stackWarnings, atLeastSomeSuccess[1], exportedPrimaryByPhoto
@@ -457,6 +453,7 @@ function ExportTask.processRenderedPhotos(functionContext, exportContext)
 
     local failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto = runExport(
         immich, exportContext, progressScope, nPhotos, exportParams, albumId, useAlbum, editedPhotosCache)
+    progressScope:done()
 
     log:info('=== Export DONE: ' .. nPhotos .. ' photos | failures=' .. #failures
         .. ' | warnings=' .. #stackWarnings .. ' ===')

--- a/immich-plugin.lrplugin/ExportTask.lua
+++ b/immich-plugin.lrplugin/ExportTask.lua
@@ -211,16 +211,10 @@ local function processOnePhotoGroup(immich, lid, items, exportParams, albumId, u
                 local folderAlbumId = immich:createOrGetAlbumFolderBased(photo:getFormattedMetadata("folderName"))
                 if folderAlbumId then immich:addAssetToAlbum(folderAlbumId, primaryId) end
             end
-            if exportParams.originalFileMode and exportParams.originalFileMode ~= "none" then
-                local hasEdits = StackManager.hasEdits(photo, editedPhotosCache)
-                local shouldStack = (exportParams.originalFileMode == "all")
-                    or (exportParams.originalFileMode == "edited" and hasEdits)
-                    or (exportParams.originalFileMode == "original_plus_jpeg_if_edited" and hasEdits)
-                if shouldStack then
-                    local _, stackError = StackManager.processPhotoWithStack(immich, items[1].rendition, primaryId, exportParams)
-                    if stackError then table.insert(stackWarnings, filename .. ": " .. stackError) end
-                end
-            end
+            -- Note: processPhotoWithStack is intentionally NOT called here. Both renditions
+            -- (original copy + rendered export) have already been uploaded and stacked by
+            -- immich:createStack above. Calling processPhotoWithStack would re-upload the disk
+            -- original under a different deviceAssetId and create a duplicate stack.
         end
     elseif #items == 1 then
         -- One rendition arrived (the other failed to render or was not expected for this photo/mode).
@@ -231,7 +225,7 @@ local function processOnePhotoGroup(immich, lid, items, exportParams, albumId, u
         local id = StackManager.uploadOneAssetOrReplace(immich, item.path, deviceAssetId, filename, dateCreated)
         UploadHelpers.safeDeleteTempFile(item.path)
         if not id then
-            table.insert(failures, filename)
+            table.insert(failures, item.path)
         else
             atLeastSomeSuccess[1] = true
             local primaryId = id
@@ -283,7 +277,8 @@ local function processStackOriginalExportRenditions(immich, exportContext, progr
         local success, pathOrMessage = rendition:waitForRender()
         if progressScope:isCanceled() then break end
         if success then
-            local lid = rendition.photo.localIdentifier
+            -- Use stable device ID (UUID when available) so deviceAssetIds survive catalog re-imports.
+            local lid = util.getPhotoDeviceId(rendition.photo) or rendition.photo.localIdentifier
             if not accumulator[lid] then accumulator[lid] = {} end
             local srcPath = StackManager.getOriginalFilePath(rendition.photo)
             local srcExt = srcPath and util.getExtension(srcPath) or ""

--- a/immich-plugin.lrplugin/ExportTask.lua
+++ b/immich-plugin.lrplugin/ExportTask.lua
@@ -185,10 +185,10 @@ local function processOnePhotoGroup(immich, lid, items, exportParams, albumId, u
         UploadHelpers.sortOriginalExportItems(items)
         local assetIds = {}
         local primaryId = nil
-        local originalPath = StackManager.getOriginalFilePath(photo)
-        for _, item in ipairs(items) do
-            local isOriginal = originalPath ~= nil and (item.path == originalPath)
-            local deviceAssetId = lid .. (isOriginal and "_orig" or "_export")
+        for i, item in ipairs(items) do
+            -- After sort: items[1]=export (primary), items[2]=original.
+            -- Index-based suffix guarantees distinct IDs regardless of format pairing.
+            local deviceAssetId = lid .. (i == 1 and "_export" or "_orig")
             local id = StackManager.uploadOneAssetOrReplace(immich, item.path, deviceAssetId, filename, dateCreated)
             UploadHelpers.safeDeleteTempFile(item.path)
             if not id then
@@ -222,83 +222,50 @@ local function processOnePhotoGroup(immich, lid, items, exportParams, albumId, u
                 end
             end
         end
-    elseif #items == 1 and (exportParams.originalFileMode == "original_only" or exportParams.originalFileMode == "original_plus_jpeg_if_edited") then
-        local deviceAssetId = lid
-        local originalPath = StackManager.getOriginalFilePath(photo)
-        if not originalPath then
-            table.insert(failures, filename .. " (original not found)")
+    elseif #items == 1 then
+        -- One rendition arrived (the other failed to render or was not expected for this photo/mode).
+        -- Use isOriginal to determine the role: original copy (_orig) vs rendered export (_export).
+        local item = items[1]
+        local isOrig = item.isOriginal == true
+        local deviceAssetId = lid .. (isOrig and "_orig" or "_export")
+        local id = StackManager.uploadOneAssetOrReplace(immich, item.path, deviceAssetId, filename, dateCreated)
+        UploadHelpers.safeDeleteTempFile(item.path)
+        if not id then
+            table.insert(failures, filename)
         else
-            local existingId, existingDeviceId = immich:checkIfAssetExistsEnhanced(photo, deviceAssetId, filename, dateCreated)
-            local id
-            if existingId == nil then
-                id = immich:uploadAsset(originalPath, deviceAssetId)
+            atLeastSomeSuccess[1] = true
+            local primaryId = id
+            if not isOrig then
+                -- Export rendition arrived; upload disk original and create stack.
+                local originalPath = StackManager.getOriginalFilePath(photo)
+                if originalPath then
+                    local origId = StackManager.uploadOneAssetOrReplace(immich, originalPath, lid .. "_orig", filename, dateCreated)
+                    if origId then
+                        if not immich:createStack({ id, origId }) then
+                            table.insert(stackWarnings, filename .. ": failed to create original+export stack")
+                        end
+                    else
+                        table.insert(stackWarnings, filename .. ": failed to upload original file")
+                    end
+                else
+                    table.insert(stackWarnings, filename .. ": original file not accessible; uploaded export only")
+                end
             else
-                id = immich:replaceAsset(existingId, originalPath, existingDeviceId or deviceAssetId)
-            end
-            if not id then
-                table.insert(failures, originalPath)
-            else
-                atLeastSomeSuccess[1] = true
-                local primaryId = id
+                -- Original copy arrived; export did not render or is not expected in this mode/format.
                 if exportParams.originalFileMode == "original_plus_jpeg_if_edited" and StackManager.hasEdits(photo, editedPhotosCache) then
                     if string.upper(exportParams.LR_format or "") == "ORIGINAL" then
                         table.insert(stackWarnings, filename .. ": skipped rendered export — 'Original / no reformat' does not produce an edited version. Change export format to JPEG or TIFF.")
                     else
-                        local deviceAssetIdEdited = tostring(deviceAssetId) .. "_edited"
-                        local existingExportId, existingExportDeviceId = immich:checkIfAssetExists(deviceAssetIdEdited, filename, dateCreated)
-                        local exportId
-                        if existingExportId then
-                            exportId = immich:replaceAsset(existingExportId, items[1].path, existingExportDeviceId or deviceAssetIdEdited)
-                        else
-                            exportId = immich:uploadAsset(items[1].path, deviceAssetIdEdited)
-                        end
-                        if exportId then
-                            primaryId = exportId
-                            if not immich:createStack({ exportId, id }) then
-                                table.insert(stackWarnings, filename .. ": Failed to create stack")
-                            end
-                        else
-                            table.insert(stackWarnings, filename .. ": failed to upload rendered export")
-                        end
-                    end
-                end
-                exportedPrimaryByPhoto[photo.localIdentifier] = { assetId = primaryId, photo = photo }
-                if useAlbum then immich:addAssetToAlbum(albumId, primaryId)
-                elseif exportParams.albumMode == "folder" then
-                    local folderAlbumId = immich:createOrGetAlbumFolderBased(photo:getFormattedMetadata("folderName"))
-                    if folderAlbumId then immich:addAssetToAlbum(folderAlbumId, primaryId) end
-                end
-            end
-        end
-        UploadHelpers.safeDeleteTempFile(items[1].path)
-    else
-        local firstPrimaryId = nil
-        for i, item in ipairs(items) do
-            local deviceAssetId = (#items == 1) and lid or (lid .. "_" .. tostring(i))
-            local id = StackManager.uploadOneAssetOrReplace(immich, item.path, deviceAssetId, filename, dateCreated)
-            UploadHelpers.safeDeleteTempFile(item.path)
-            if not id then
-                table.insert(failures, item.path)
-            else
-                atLeastSomeSuccess[1] = true
-                if firstPrimaryId == nil then firstPrimaryId = id end
-                if useAlbum then immich:addAssetToAlbum(albumId, id)
-                elseif exportParams.albumMode == "folder" then
-                    local folderAlbumId = immich:createOrGetAlbumFolderBased(photo:getFormattedMetadata("folderName"))
-                    if folderAlbumId then immich:addAssetToAlbum(folderAlbumId, id) end
-                end
-                if #items == 1 and exportParams.originalFileMode and exportParams.originalFileMode ~= "none" and exportParams.originalFileMode ~= "original_plus_jpeg_if_edited" then
-                    local hasEdits = StackManager.hasEdits(photo, editedPhotosCache)
-                    local shouldStack = (exportParams.originalFileMode == "all") or (exportParams.originalFileMode == "edited" and hasEdits)
-                    if shouldStack then
-                        local _, stackError = StackManager.processPhotoWithStack(immich, item.rendition, id, exportParams)
-                        if stackError then table.insert(stackWarnings, filename .. ": " .. stackError) end
+                        table.insert(stackWarnings, filename .. ": rendered export did not arrive; uploaded original only")
                     end
                 end
             end
-        end
-        if firstPrimaryId then
-            exportedPrimaryByPhoto[lid] = { assetId = firstPrimaryId, photo = photo }
+            exportedPrimaryByPhoto[photo.localIdentifier] = { assetId = primaryId, photo = photo }
+            if useAlbum then immich:addAssetToAlbum(albumId, primaryId)
+            elseif exportParams.albumMode == "folder" then
+                local folderAlbumId = immich:createOrGetAlbumFolderBased(photo:getFormattedMetadata("folderName"))
+                if folderAlbumId then immich:addAssetToAlbum(folderAlbumId, primaryId) end
+            end
         end
     end
 end
@@ -318,11 +285,16 @@ local function processStackOriginalExportRenditions(immich, exportContext, progr
         if success then
             local lid = rendition.photo.localIdentifier
             if not accumulator[lid] then accumulator[lid] = {} end
+            local srcPath = StackManager.getOriginalFilePath(rendition.photo)
+            local srcExt = srcPath and util.getExtension(srcPath) or ""
+            local itemExt = util.getExtension(pathOrMessage)
             table.insert(accumulator[lid], {
                 path = pathOrMessage,
                 photo = rendition.photo,
                 rendition = rendition,
-                ext = util.getExtension(pathOrMessage),
+                ext = itemExt,
+                isOriginal = srcExt ~= "" and itemExt == srcExt,
+                insertionOrder = #accumulator[lid],  -- 0-based; used as stable sort tiebreaker
             })
             -- Both renditions for this photo are ready: upload and stack immediately.
             if #accumulator[lid] == 2 then

--- a/immich-plugin.lrplugin/ExportTask.lua
+++ b/immich-plugin.lrplugin/ExportTask.lua
@@ -232,18 +232,25 @@ local function processOnePhotoGroup(immich, lid, items, exportParams, albumId, u
         else
             atLeastSomeSuccess[1] = true
             local primaryId = id
-            local originalPath = StackManager.getOriginalFilePath(photo)
-            if originalPath then
-                local origId = StackManager.uploadOneAssetOrReplace(immich, originalPath, lid .. "_orig", filename, dateCreated)
-                if origId then
-                    if not immich:createStack({ id, origId }) then
-                        table.insert(stackWarnings, filename .. ": failed to create original+export stack")
+            if string.upper(exportParams.LR_format or "") == "ORIGINAL" then
+                -- LR_format == "ORIGINAL" means Lightroom copied the source byte-for-byte; the
+                -- rendition IS the original. Uploading the disk original as _orig would create two
+                -- identical assets. Skip original upload and warn instead.
+                table.insert(stackWarnings, filename .. ": skipped original+export stack — 'Original / no reformat' produces an identical copy. Switch to any rendered format (e.g. JPEG, TIFF, PNG).")
+            else
+                local originalPath = StackManager.getOriginalFilePath(photo)
+                if originalPath then
+                    local origId = StackManager.uploadOneAssetOrReplace(immich, originalPath, lid .. "_orig", filename, dateCreated)
+                    if origId then
+                        if not immich:createStack({ id, origId }) then
+                            table.insert(stackWarnings, filename .. ": failed to create original+export stack")
+                        end
+                    else
+                        table.insert(stackWarnings, filename .. ": failed to upload original file")
                     end
                 else
-                    table.insert(stackWarnings, filename .. ": failed to upload original file")
+                    table.insert(stackWarnings, filename .. ": original file not accessible; uploaded export only")
                 end
-            else
-                table.insert(stackWarnings, filename .. ": original file not accessible; uploaded export only")
             end
             exportedPrimaryByPhoto[photo.localIdentifier] = { assetId = primaryId, photo = photo }
             if useAlbum then immich:addAssetToAlbum(albumId, primaryId)

--- a/immich-plugin.lrplugin/ExportTask.lua
+++ b/immich-plugin.lrplugin/ExportTask.lua
@@ -185,8 +185,10 @@ local function processOnePhotoGroup(immich, lid, items, exportParams, albumId, u
         UploadHelpers.sortOriginalExportItems(items)
         local assetIds = {}
         local primaryId = nil
+        local originalPath = StackManager.getOriginalFilePath(photo)
         for _, item in ipairs(items) do
-            local deviceAssetId = lid .. "_" .. util.getExtension(item.path)
+            local isOriginal = originalPath ~= nil and (item.path == originalPath)
+            local deviceAssetId = lid .. (isOriginal and "_orig" or "_export")
             local id = StackManager.uploadOneAssetOrReplace(immich, item.path, deviceAssetId, filename, dateCreated)
             UploadHelpers.safeDeleteTempFile(item.path)
             if not id then

--- a/immich-plugin.lrplugin/ExportTask.lua
+++ b/immich-plugin.lrplugin/ExportTask.lua
@@ -192,8 +192,8 @@ local function processOnePhotoGroup(immich, lid, items, exportParams, albumId, u
         UploadHelpers.sortDngJpgItems(items)
         local assetIds = {}
         local primaryId = nil
-        for i, item in ipairs(items) do
-            local deviceAssetId = lid .. "_" .. tostring(i)
+        for _, item in ipairs(items) do
+            local deviceAssetId = lid .. "_" .. util.getExtension(item.path)
             local id = StackManager.uploadOneAssetOrReplace(immich, item.path, deviceAssetId, filename, dateCreated)
             UploadHelpers.safeDeleteTempFile(item.path)
             if not id then
@@ -233,35 +233,43 @@ local function processOnePhotoGroup(immich, lid, items, exportParams, albumId, u
         if not originalPath then
             table.insert(failures, filename .. " (original not found)")
         else
-            local existingId, existingDeviceId = immich:checkIfAssetExists(deviceAssetId, filename, dateCreated)
+            local existingId, existingDeviceId = immich:checkIfAssetExistsEnhanced(photo, deviceAssetId, filename, dateCreated)
             local id
             if existingId == nil then
                 id = immich:uploadAsset(originalPath, deviceAssetId)
             else
-                id = immich:replaceAsset(existingId, originalPath, existingDeviceId)
+                id = immich:replaceAsset(existingId, originalPath, existingDeviceId or deviceAssetId)
             end
             if not id then
                 table.insert(failures, originalPath)
             else
                 atLeastSomeSuccess[1] = true
+                local primaryId = id
                 if exportParams.originalFileMode == "original_plus_jpeg_if_edited" and StackManager.hasEdits(photo, editedPhotosCache) then
-                    local deviceAssetIdEdited = tostring(deviceAssetId) .. "_edited"
-                    local existingJpegId, existingJpegDeviceId = immich:checkIfAssetExists(deviceAssetIdEdited, filename, dateCreated)
-                    local jpegId
-                    if existingJpegId then
-                        jpegId = immich:replaceAsset(existingJpegId, items[1].path, existingJpegDeviceId or deviceAssetIdEdited)
+                    if string.upper(exportParams.LR_format or "") == "ORIGINAL" then
+                        table.insert(stackWarnings, filename .. ": skipped rendered export — 'Original / no reformat' does not produce an edited version. Change export format to JPEG or TIFF.")
                     else
-                        jpegId = immich:uploadAsset(items[1].path, deviceAssetIdEdited)
-                    end
-                    if jpegId and not immich:createStack({ id, jpegId }) then
-                        table.insert(stackWarnings, filename .. ": Failed to create stack")
+                        local deviceAssetIdEdited = tostring(deviceAssetId) .. "_edited"
+                        local existingJpegId, existingJpegDeviceId = immich:checkIfAssetExists(deviceAssetIdEdited, filename, dateCreated)
+                        local jpegId
+                        if existingJpegId then
+                            jpegId = immich:replaceAsset(existingJpegId, items[1].path, existingJpegDeviceId or deviceAssetIdEdited)
+                        else
+                            jpegId = immich:uploadAsset(items[1].path, deviceAssetIdEdited)
+                        end
+                        if jpegId then
+                            primaryId = jpegId
+                            if not immich:createStack({ jpegId, id }) then
+                                table.insert(stackWarnings, filename .. ": Failed to create stack")
+                            end
+                        end
                     end
                 end
-                exportedPrimaryByPhoto[photo.localIdentifier] = { assetId = id, photo = photo }
-                if useAlbum then immich:addAssetToAlbum(albumId, id)
+                exportedPrimaryByPhoto[photo.localIdentifier] = { assetId = primaryId, photo = photo }
+                if useAlbum then immich:addAssetToAlbum(albumId, primaryId)
                 elseif exportParams.albumMode == "folder" then
                     local folderAlbumId = immich:createOrGetAlbumFolderBased(photo:getFormattedMetadata("folderName"))
-                    if folderAlbumId then immich:addAssetToAlbum(folderAlbumId, id) end
+                    if folderAlbumId then immich:addAssetToAlbum(folderAlbumId, primaryId) end
                 end
             end
         end
@@ -342,29 +350,35 @@ local function processSingleRenditionRenditions(immich, exportContext, progressS
                         table.insert(failures, photo:getFormattedMetadata("fileName"))
                     else
                         atLeastSomeSuccess = true
+                        local primaryId = id
                         if originalFileMode == 'original_plus_jpeg_if_edited' and StackManager.hasEdits(photo, editedPhotosCache) then
-                            local deviceAssetIdEdited = tostring(deviceAssetId) .. "_edited"
-                            local fileName, dateCreated = photo:getFormattedMetadata("fileName"), photo:getFormattedMetadata("dateCreated")
-                            local existingJpegId, existingJpegDeviceId = immich:checkIfAssetExists(deviceAssetIdEdited, fileName, dateCreated)
-                            local jpegId
-                            if existingJpegId then
-                                jpegId = immich:replaceAsset(existingJpegId, pathOrMessage, existingJpegDeviceId or deviceAssetIdEdited)
+                            if string.upper(exportParams.LR_format or "") == "ORIGINAL" then
+                                table.insert(stackWarnings, photo:getFormattedMetadata("fileName") .. ": skipped rendered export — 'Original / no reformat' does not produce an edited version. Change export format to JPEG or TIFF.")
                             else
-                                jpegId = immich:uploadAsset(pathOrMessage, deviceAssetIdEdited)
-                            end
-                            if jpegId then
-                                if not immich:createStack({ id, jpegId }) then
-                                    table.insert(stackWarnings, photo:getFormattedMetadata("fileName") .. ": failed to create stack")
+                                local deviceAssetIdEdited = tostring(deviceAssetId) .. "_edited"
+                                local fileName, dateCreated = photo:getFormattedMetadata("fileName"), photo:getFormattedMetadata("dateCreated")
+                                local existingJpegId, existingJpegDeviceId = immich:checkIfAssetExists(deviceAssetIdEdited, fileName, dateCreated)
+                                local jpegId
+                                if existingJpegId then
+                                    jpegId = immich:replaceAsset(existingJpegId, pathOrMessage, existingJpegDeviceId or deviceAssetIdEdited)
+                                else
+                                    jpegId = immich:uploadAsset(pathOrMessage, deviceAssetIdEdited)
                                 end
-                            else
-                                table.insert(stackWarnings, photo:getFormattedMetadata("fileName") .. ": failed to upload JPG")
+                                if jpegId then
+                                    primaryId = jpegId
+                                    if not immich:createStack({ jpegId, id }) then
+                                        table.insert(stackWarnings, photo:getFormattedMetadata("fileName") .. ": failed to create stack")
+                                    end
+                                else
+                                    table.insert(stackWarnings, photo:getFormattedMetadata("fileName") .. ": failed to upload JPG")
+                                end
                             end
                         end
-                        exportedPrimaryByPhoto[photo.localIdentifier] = { assetId = id, photo = photo }
-                        if useAlbum then immich:addAssetToAlbum(albumId, id)
+                        exportedPrimaryByPhoto[photo.localIdentifier] = { assetId = primaryId, photo = photo }
+                        if useAlbum then immich:addAssetToAlbum(albumId, primaryId)
                         elseif exportParams.albumMode == 'folder' then
                             local folderAlbumId = immich:createOrGetAlbumFolderBased(photo:getFormattedMetadata("folderName"))
-                            if folderAlbumId then immich:addAssetToAlbum(folderAlbumId, id) end
+                            if folderAlbumId then immich:addAssetToAlbum(folderAlbumId, primaryId) end
                         end
                     end
                 end

--- a/immich-plugin.lrplugin/ExportTask.lua
+++ b/immich-plugin.lrplugin/ExportTask.lua
@@ -333,7 +333,7 @@ local function processSingleRenditionRenditions(immich, exportContext, progressS
                     local id = (existingId == nil) and immich:uploadAsset(originalPath, deviceAssetId)
                         or immich:replaceAsset(existingId, originalPath, existingDeviceId or deviceAssetId)
                     if not id then
-                        table.insert(failures, photo:getFormattedMetadata("fileName"))
+                        table.insert(failures, photo:getFormattedMetadata("fileName") .. " - " .. originalPath)
                     else
                         atLeastSomeSuccess = true
                         local primaryId = id

--- a/immich-plugin.lrplugin/ImmichAPI.lua
+++ b/immich-plugin.lrplugin/ImmichAPI.lua
@@ -1074,7 +1074,7 @@ function ImmichAPI:doMultiPartPostRequest(apiPath, mimeChunks)
     if not ensureConnectivity(self) then return nil end
 
     logRequestStart(self, 'multipart POST', apiPath)
-    local response, headers = LrHttp.postMultipart(self.url .. self.apiBasePath .. apiPath, mimeChunks, self:createHeadersForMultipart())
+    local response, headers = LrHttp.postMultipart(self.url .. self.apiBasePath .. apiPath, mimeChunks, self:createHeadersForMultipart(), HTTP_TIMEOUT_UPLOAD)
 
     if not headers then
         log:error('ImmichAPI multipart POST: no response headers (network error): ' .. apiPath)

--- a/immich-plugin.lrplugin/ImmichAPI.lua
+++ b/immich-plugin.lrplugin/ImmichAPI.lua
@@ -5,8 +5,8 @@
 
 -- Constants
 local API_BASE_PATH = '/api'
-local HTTP_TIMEOUT_DEFAULT = 5
-local HTTP_TIMEOUT_UPLOAD = 15
+local HTTP_TIMEOUT_DEFAULT = 30
+local HTTP_TIMEOUT_UPLOAD = 300
 local DEVICE_ID_STRING = 'Lightroom Immich Upload Plugin'
 
 local SUCCESS_STATUS_GET = 200
@@ -63,7 +63,7 @@ local function generateMultiPartBody(boundary, formData, filePath)
         return nil
     end
     local fileName = LrPathUtils.leafName(filePath)
-    local body = ''
+    local parts = {}
     local boundaryLine = '--' .. boundary .. '\r\n'
 
     for i = 1, #formData do
@@ -71,9 +71,9 @@ local function generateMultiPartBody(boundary, formData, filePath)
         local name = part and part.name
         local value = part and part.value
         if name then
-            body = body .. boundaryLine
-            body = body .. 'Content-Disposition: form-data; name="' .. name .. '"\r\n\r\n'
-            body = body .. tostring(value or '') .. "\r\n"
+            parts[#parts + 1] = boundaryLine
+            parts[#parts + 1] = 'Content-Disposition: form-data; name="' .. name .. '"\r\n\r\n'
+            parts[#parts + 1] = tostring(value or '') .. "\r\n"
         end
     end
 
@@ -89,13 +89,13 @@ local function generateMultiPartBody(boundary, formData, filePath)
         return nil
     end
 
-    body = body .. boundaryLine
-    body = body .. 'Content-Disposition: form-data; name="assetData"; filename="' .. fileName .. '"\r\n'
-    body = body .. 'Content-Type: application/octet-stream\r\n\r\n'
-    body = body .. fileContent
-    body = body .. '\r\n--' .. boundary .. '--\r\n'
+    parts[#parts + 1] = boundaryLine
+    parts[#parts + 1] = 'Content-Disposition: form-data; name="assetData"; filename="' .. fileName .. '"\r\n'
+    parts[#parts + 1] = 'Content-Type: application/octet-stream\r\n\r\n'
+    parts[#parts + 1] = fileContent
+    parts[#parts + 1] = '\r\n--' .. boundary .. '--\r\n'
 
-    return body
+    return table.concat(parts)
 end
 
 -- ---------------------------------------------------------------------------
@@ -988,7 +988,7 @@ function ImmichAPI:doPostRequest(apiPath, postBody)
     if postBody ~= nil then
         log:trace('ImmichAPI: Postbody ' .. JSON:encode(postBody))
     end
-    local response, headers = LrHttp.post(self.url .. self.apiBasePath .. apiPath, JSON:encode(postBody), self:createHeaders())
+    local response, headers = LrHttp.post(self.url .. self.apiBasePath .. apiPath, JSON:encode(postBody), self:createHeaders(), 'POST', HTTP_TIMEOUT_DEFAULT)
 
     if not headers then
         log:error('ImmichAPI POST: no response headers (network error): ' .. apiPath)

--- a/immich-plugin.lrplugin/ImmichAPI.lua
+++ b/immich-plugin.lrplugin/ImmichAPI.lua
@@ -39,64 +39,20 @@ end
 
 local function logRequestStart(api, method, apiPath)
     log:trace('ImmichAPI: Preparing ' .. method .. ' request ' .. api.url .. api.apiBasePath .. apiPath)
-    log:trace('ImmichAPI: ' .. util.cutApiKey(api.apiKey))
 end
 
 local function handleRequestFailure(method, apiPath, status, headers, response)
-    local detail = (headers and util.dumpTable(headers)) or "No headers"
-    ErrorHandler.handleError(
-        'ImmichAPI ' .. tostring(method) .. ' request failed. ' .. apiPath .. ' (status ' .. tostring(status or '?') .. ')',
-        detail
-    )
+    -- Log the failure; do not show a modal dialog. During batch exports many requests can fail
+    -- (e.g. one stack per photo). A modal dialog per failure would block the entire export and
+    -- force the user to dismiss hundreds of popups. Callers check the nil return value and
+    -- collect failures for the post-export summary shown by reportUploadFailuresAndWarnings.
+    log:error('ImmichAPI ' .. tostring(method) .. ' request failed: ' .. apiPath .. ' (status ' .. tostring(status or '?') .. ')')
+    log:error('Response headers: ' .. ((headers and util.dumpTable(headers)) or "none"))
     if response ~= nil then
         log:error('Response body: ' .. tostring(response))
     end
 end
 
-local function generateBoundary()
-    return "ImmichUpload" .. tostring(math.random(100000, 999999))
-end
-
-local function generateMultiPartBody(boundary, formData, filePath)
-    if not boundary or not formData or not filePath or type(filePath) ~= "string" then
-        log:error('generateMultiPartBody: invalid arguments (boundary, formData or filePath missing)')
-        return nil
-    end
-    local fileName = LrPathUtils.leafName(filePath)
-    local parts = {}
-    local boundaryLine = '--' .. boundary .. '\r\n'
-
-    for i = 1, #formData do
-        local part = formData[i]
-        local name = part and part.name
-        local value = part and part.value
-        if name then
-            parts[#parts + 1] = boundaryLine
-            parts[#parts + 1] = 'Content-Disposition: form-data; name="' .. name .. '"\r\n\r\n'
-            parts[#parts + 1] = tostring(value or '') .. "\r\n"
-        end
-    end
-
-    local fh = io.open(filePath, "rb")
-    if not fh then
-        log:error('generateMultiPartBody: unable to open file: ' .. tostring(filePath))
-        return nil
-    end
-    local fileContent = fh:read("*all")
-    fh:close()
-    if not fileContent then
-        log:error('generateMultiPartBody: failed to read file: ' .. filePath)
-        return nil
-    end
-
-    parts[#parts + 1] = boundaryLine
-    parts[#parts + 1] = 'Content-Disposition: form-data; name="assetData"; filename="' .. fileName .. '"\r\n'
-    parts[#parts + 1] = 'Content-Type: application/octet-stream\r\n\r\n'
-    parts[#parts + 1] = fileContent
-    parts[#parts + 1] = '\r\n--' .. boundary .. '--\r\n'
-
-    return table.concat(parts)
-end
 
 -- ---------------------------------------------------------------------------
 -- Configuration
@@ -266,14 +222,6 @@ function ImmichAPI:createHeadersForMultipart()
     }
 end
 
-function ImmichAPI:createHeadersForMultipartPut(boundary, length)
-    return {
-        { field = 'x-api-key',      value = safeApiKey(self) },
-        { field = 'Accept',         value = 'application/json' },
-        { field = 'Content-Type',   value = 'multipart/form-data; boundary="' .. boundary .. '"' },
-        { field = 'Content-Length', value = tostring(length) },
-    }
-end
 
 -- Returns sanitized URL (string) on success; false on empty; nil on invalid format.
 -- Does not show dialogs (for use in validate callbacks). Callers should show errors or return error messages.
@@ -418,6 +366,7 @@ function ImmichAPI:uploadAsset(pathOrMessage, deviceAssetId)
 
     local parsedResponse = self:doMultiPartPostRequest(apiPath, mimeChunks)
     if parsedResponse ~= nil then
+        log:info('uploadAsset: ' .. tostring(deviceAssetId) .. ' -> ' .. parsedResponse.id)
         return parsedResponse.id
     end
     return nil
@@ -448,7 +397,7 @@ function ImmichAPI:replaceAsset(immichId, pathOrMessage, deviceAssetId)
         end
         if self:copyAssetMetadata(immichId, newImmichId) then
             if self:deleteAsset(immichId) then
-                log:trace('copyAssetMetadata: Successfully replaced asset ' .. immichId .. ' with new asset ' .. newImmichId)
+                log:info('replaceAsset: ' .. immichId .. ' -> ' .. newImmichId)
                 return newImmichId
             else
                 ErrorHandler.handleError('Failed to delete old asset after replacement. Check logs.',
@@ -565,10 +514,10 @@ function ImmichAPI:createStack(assetIds)
     local postBody = { assetIds = assetIds }
 
     log:trace('Creating stack with assets: ' .. JSON:encode(assetIds))
-    
+
     local parsedResponse = self:doPostRequest(apiPath, postBody)
     if parsedResponse ~= nil then
-        log:trace('Stack created successfully with ID: ' .. parsedResponse.id)
+        log:info('Stack created: ' .. parsedResponse.id .. ' (' .. #assetIds .. ' assets)')
         return parsedResponse.id
     else
         log:error('Failed to create stack')
@@ -1088,35 +1037,3 @@ function ImmichAPI:doMultiPartPostRequest(apiPath, mimeChunks)
     return nil
 end
 
-function ImmichAPI:doMultiPartPutRequest(apiPath, filePath, formData)
-    if not ensureConnectivity(self) then return nil end
-
-    logRequestStart(self, 'multipart PUT', apiPath)
-    local url = self.url .. self.apiBasePath .. apiPath
-    local boundary = generateBoundary()
-    local body = generateMultiPartBody(boundary, formData, filePath)
-    if not body then
-        log:error('doMultiPartPutRequest: failed to build multipart body for ' .. tostring(filePath))
-        ErrorHandler.handleError('Could not read or build upload data. Check file path and permissions.', 'Upload failed')
-        return nil
-    end
-    local reqhdrs = self:createHeadersForMultipartPut(boundary, string.len(body))
-    log:trace('ImmichAPI multipart PUT headers:' .. util.dumpTable(reqhdrs))
-
-    local response, headers = LrHttp.post(url, body, reqhdrs, 'PUT', HTTP_TIMEOUT_UPLOAD)
-    if headers then
-        log:trace('ImmichAPI multipart PUT response headers ' .. util.dumpTable(headers))
-    end
-
-    if not headers then
-        log:error('ImmichAPI multipart PUT: no response headers (network error): ' .. apiPath)
-        ErrorHandler.handleError('No response from Immich server. Check URL and network.', 'Connection failed')
-        return nil
-    end
-    if SUCCESS_STATUS_POST[headers.status] then
-        log:trace('ImmichAPI multipart PUT request succeeded: ' .. tostring(response))
-        return safeDecodeJson(response, 'multipart PUT')
-    end
-    handleRequestFailure('multipart PUT', apiPath, headers.status, headers, response)
-    return nil
-end

--- a/immich-plugin.lrplugin/PublishDialogSections.lua
+++ b/immich-plugin.lrplugin/PublishDialogSections.lua
@@ -83,13 +83,13 @@ function PublishDialogSections.sectionsForTopOfDialog(f, propertyTable)
 			f:column {
 				f:row {
 					f:static_text {
-						title = "DNG+JPG:",
+						title = "Original + Export:",
 						alignment = 'right',
 						width = LrView.share "label_width",
 					},
 					f:checkbox {
-						title = "Stack in Immich (edited JPG as primary)",
-						value = bind 'stackDngJpg',
+						title = "Stack in Immich (export as primary)",
+						value = bind 'stackOriginalExport',
 					},
 				},
 				f:row {

--- a/immich-plugin.lrplugin/PublishServiceProvider.lua
+++ b/immich-plugin.lrplugin/PublishServiceProvider.lua
@@ -16,7 +16,7 @@ return {
 	exportPresetFields = {
 		{ key = 'url', default = '' },
 		{ key = "apiKey", default = '' },
-		{ key = 'stackDngJpg', default = false },
+		{ key = 'stackOriginalExport', default = false },
 		{ key = 'stackLrStacks', default = false },
 	},
 

--- a/immich-plugin.lrplugin/PublishTask.lua
+++ b/immich-plugin.lrplugin/PublishTask.lua
@@ -98,20 +98,12 @@ local function processPublishOnePhotoGroup(immich, lid, items, albumCreationStra
             item.rendition:recordPublishedPhotoId(id)
             item.rendition:recordPublishedPhotoUrl(immich:getAssetUrl(id))
             if not isOrig then
-                -- Export rendition arrived; upload disk original and create stack.
-                local originalPath = StackManager.getOriginalFilePath(photo)
-                if originalPath then
-                    local origId = StackManager.uploadOneAssetOrReplace(immich, originalPath, lid .. "_orig", filename, dateCreated)
-                    if origId then
-                        if not immich:createStack({ id, origId }) then
-                            table.insert(stackWarnings, filename .. ": failed to create original+export stack")
-                        end
-                    else
-                        table.insert(stackWarnings, filename .. ": failed to upload original file")
-                    end
-                else
-                    table.insert(stackWarnings, filename .. ": original file not accessible; uploaded export only")
-                end
+                -- Export rendition arrived but original rendition did not. Do NOT upload the disk
+                -- original here: assets uploaded outside of rendition:recordPublishedPhotoId cannot
+                -- be tracked by Lightroom and will become orphans when the photo is later removed
+                -- from the publish collection (deletePhotosFromPublishedCollection only cleans up
+                -- assets registered via recordPublishedPhotoId). Warn instead.
+                table.insert(stackWarnings, filename .. ": only export rendition available; original not uploaded to avoid untracked orphan in Immich")
             end
             exportedPrimaryByPhoto[photo.localIdentifier] = { assetId = primaryId, photo = photo }
             addAssetToPublishAlbum(immich, albumCreationStrategy, albumId, albumAssetIds, primaryId,

--- a/immich-plugin.lrplugin/PublishTask.lua
+++ b/immich-plugin.lrplugin/PublishTask.lua
@@ -115,7 +115,7 @@ end
 --------------------------------------------------------------------------------
 -- Original+export flow: accumulate renditions per photo, flush each group as soon as
 -- both renditions are ready. This avoids buffering all renders before any upload starts.
-local function processPublishStackOriginalExportRenditions(immich, exportContext, progressScope, exportParams,
+local function processPublishStackOriginalExportRenditions(immich, exportContext, progressScope,
     albumCreationStrategy, albumId, albumAssetIds)
     local failures, stackWarnings = {}, {}
     local atLeastSomeSuccess = { false }
@@ -208,7 +208,7 @@ local function runPublishExport(immich, exportContext, progressScope, exportPara
     local failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto
     if exportParams.stackOriginalExport then
         failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto = processPublishStackOriginalExportRenditions(
-            immich, exportContext, progressScope, exportParams, albumCreationStrategy, albumId, albumAssetIds)
+            immich, exportContext, progressScope, albumCreationStrategy, albumId, albumAssetIds)
     else
         failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto = processPublishSingleRenditionRenditions(
             immich, exportContext, progressScope, exportParams, albumCreationStrategy, albumId, albumAssetIds)

--- a/immich-plugin.lrplugin/PublishTask.lua
+++ b/immich-plugin.lrplugin/PublishTask.lua
@@ -56,10 +56,10 @@ local function processPublishOnePhotoGroup(immich, lid, items, albumCreationStra
         UploadHelpers.sortOriginalExportItems(items)
         local assetIds = {}
         local primaryId = nil
-        local originalPath = StackManager.getOriginalFilePath(photo)
-        for _, item in ipairs(items) do
-            local isOriginal = originalPath ~= nil and (item.path == originalPath)
-            local deviceAssetId = lid .. (isOriginal and "_orig" or "_export")
+        for i, item in ipairs(items) do
+            -- After sort: items[1]=export (primary), items[2]=original.
+            -- Index-based suffix guarantees distinct IDs regardless of format pairing.
+            local deviceAssetId = lid .. (i == 1 and "_export" or "_orig")
             local id = StackManager.uploadOneAssetOrReplace(immich, item.path, deviceAssetId, filename, dateCreated)
             UploadHelpers.safeDeleteTempFile(item.path)
             if not id then
@@ -82,25 +82,40 @@ local function processPublishOnePhotoGroup(immich, lid, items, albumCreationStra
             addAssetToPublishAlbum(immich, albumCreationStrategy, albumId, albumAssetIds, primaryId,
                 photo:getFormattedMetadata("folderName"))
         end
-    else
-        local firstPrimaryId = nil
-        for i, item in ipairs(items) do
-            local deviceAssetId = (#items == 1) and lid or (lid .. "_" .. tostring(i))
-            local id = StackManager.uploadOneAssetOrReplace(immich, item.path, deviceAssetId, filename, dateCreated)
-            UploadHelpers.safeDeleteTempFile(item.path)
-            if not id then
-                table.insert(failures, item.path)
-            else
-                atLeastSomeSuccess[1] = true
-                if firstPrimaryId == nil then firstPrimaryId = id end
-                item.rendition:recordPublishedPhotoId(id)
-                item.rendition:recordPublishedPhotoUrl(immich:getAssetUrl(id))
-                addAssetToPublishAlbum(immich, albumCreationStrategy, albumId, albumAssetIds, id,
-                    photo:getFormattedMetadata("folderName"))
+    elseif #items == 1 then
+        -- One rendition arrived (the other failed to render or was not expected for this photo/mode).
+        -- Use isOriginal to determine the role: original copy (_orig) vs rendered export (_export).
+        local item = items[1]
+        local isOrig = item.isOriginal == true
+        local deviceAssetId = lid .. (isOrig and "_orig" or "_export")
+        local id = StackManager.uploadOneAssetOrReplace(immich, item.path, deviceAssetId, filename, dateCreated)
+        UploadHelpers.safeDeleteTempFile(item.path)
+        if not id then
+            table.insert(failures, item.path)
+        else
+            atLeastSomeSuccess[1] = true
+            local primaryId = id
+            item.rendition:recordPublishedPhotoId(id)
+            item.rendition:recordPublishedPhotoUrl(immich:getAssetUrl(id))
+            if not isOrig then
+                -- Export rendition arrived; upload disk original and create stack.
+                local originalPath = StackManager.getOriginalFilePath(photo)
+                if originalPath then
+                    local origId = StackManager.uploadOneAssetOrReplace(immich, originalPath, lid .. "_orig", filename, dateCreated)
+                    if origId then
+                        if not immich:createStack({ id, origId }) then
+                            table.insert(stackWarnings, filename .. ": failed to create original+export stack")
+                        end
+                    else
+                        table.insert(stackWarnings, filename .. ": failed to upload original file")
+                    end
+                else
+                    table.insert(stackWarnings, filename .. ": original file not accessible; uploaded export only")
+                end
             end
-        end
-        if firstPrimaryId then
-            exportedPrimaryByPhoto[lid] = { assetId = firstPrimaryId, photo = photo }
+            exportedPrimaryByPhoto[photo.localIdentifier] = { assetId = primaryId, photo = photo }
+            addAssetToPublishAlbum(immich, albumCreationStrategy, albumId, albumAssetIds, primaryId,
+                photo:getFormattedMetadata("folderName"))
         end
     end
 end
@@ -121,11 +136,16 @@ local function processPublishStackOriginalExportRenditions(immich, exportContext
         if success then
             local lid = rendition.photo.localIdentifier
             if not accumulator[lid] then accumulator[lid] = {} end
+            local srcPath = StackManager.getOriginalFilePath(rendition.photo)
+            local srcExt = srcPath and util.getExtension(srcPath) or ""
+            local itemExt = util.getExtension(pathOrMessage)
             table.insert(accumulator[lid], {
                 path = pathOrMessage,
                 photo = rendition.photo,
                 rendition = rendition,
-                ext = util.getExtension(pathOrMessage),
+                ext = itemExt,
+                isOriginal = srcExt ~= "" and itemExt == srcExt,
+                insertionOrder = #accumulator[lid],  -- 0-based; used as stable sort tiebreaker
             })
             -- Both renditions for this photo are ready: upload and stack immediately.
             if #accumulator[lid] == 2 then

--- a/immich-plugin.lrplugin/PublishTask.lua
+++ b/immich-plugin.lrplugin/PublishTask.lua
@@ -134,7 +134,8 @@ local function processPublishStackOriginalExportRenditions(immich, exportContext
         local success, pathOrMessage = rendition:waitForRender()
         if progressScope:isCanceled() then break end
         if success then
-            local lid = rendition.photo.localIdentifier
+            -- Use stable device ID (UUID when available) so deviceAssetIds survive catalog re-imports.
+            local lid = util.getPhotoDeviceId(rendition.photo) or rendition.photo.localIdentifier
             if not accumulator[lid] then accumulator[lid] = {} end
             local srcPath = StackManager.getOriginalFilePath(rendition.photo)
             local srcExt = srcPath and util.getExtension(srcPath) or ""

--- a/immich-plugin.lrplugin/PublishTask.lua
+++ b/immich-plugin.lrplugin/PublishTask.lua
@@ -104,7 +104,11 @@ local function processPublishOnePhotoGroup(immich, lid, items, albumCreationStra
             local primaryId = id
             item.rendition:recordPublishedPhotoId(id)
             item.rendition:recordPublishedPhotoUrl(immich:getAssetUrl(id))
-            table.insert(stackWarnings, filename .. ": only export rendition available; original not uploaded to avoid untracked orphan in Immich")
+            -- Warn once per publish run (not once per photo) to keep the post-publish dialog concise.
+            if not stackWarnings._originalNotUploadedWarned then
+                table.insert(stackWarnings, "Originals not uploaded in publish mode to avoid untracked orphans in Immich (applies to all photos in this run)")
+                stackWarnings._originalNotUploadedWarned = true
+            end
             exportedPrimaryByPhoto[photo.localIdentifier] = { assetId = primaryId, photo = photo }
             addAssetToPublishAlbum(immich, albumCreationStrategy, albumId, albumAssetIds, primaryId,
                 photo:getFormattedMetadata("folderName"))

--- a/immich-plugin.lrplugin/PublishTask.lua
+++ b/immich-plugin.lrplugin/PublishTask.lua
@@ -56,8 +56,10 @@ local function processPublishOnePhotoGroup(immich, lid, items, albumCreationStra
         UploadHelpers.sortOriginalExportItems(items)
         local assetIds = {}
         local primaryId = nil
+        local originalPath = StackManager.getOriginalFilePath(photo)
         for _, item in ipairs(items) do
-            local deviceAssetId = lid .. "_" .. util.getExtension(item.path)
+            local isOriginal = originalPath ~= nil and (item.path == originalPath)
+            local deviceAssetId = lid .. (isOriginal and "_orig" or "_export")
             local id = StackManager.uploadOneAssetOrReplace(immich, item.path, deviceAssetId, filename, dateCreated)
             UploadHelpers.safeDeleteTempFile(item.path)
             if not id then

--- a/immich-plugin.lrplugin/PublishTask.lua
+++ b/immich-plugin.lrplugin/PublishTask.lua
@@ -58,8 +58,9 @@ local function processPublishOnePhotoGroup(immich, lid, items, albumCreationStra
         local primaryId = nil
         for i, item in ipairs(items) do
             -- After sort: items[1]=export (primary), items[2]=original.
-            -- Index-based suffix guarantees distinct IDs regardless of format pairing.
-            local deviceAssetId = lid .. (i == 1 and "_export" or "_orig")
+            -- Suffix is stable for the expected two-item pair; extra renditions get an index suffix.
+            local suffix = (i == 1) and "_export" or (i == 2) and "_orig" or ("_rend" .. tostring(i))
+            local deviceAssetId = lid .. suffix
             local id = StackManager.uploadOneAssetOrReplace(immich, item.path, deviceAssetId, filename, dateCreated)
             UploadHelpers.safeDeleteTempFile(item.path)
             if not id then
@@ -192,12 +193,13 @@ local function processPublishSingleRenditionRenditions(immich, exportContext, pr
                 end
             end
             UploadHelpers.safeDeleteTempFile(pathOrMessage)
-            done = done + 1
-            progressScope:setPortionComplete(done, nPhotos)
-            if done == 1 or done % 10 == 0 or done == nPhotos then
-                log:info('Publish progress: ' .. done .. '/' .. nPhotos
-                    .. ' (' .. math.floor(done * 100 / nPhotos) .. '%)')
-            end
+        end
+        -- Advance progress for every rendition, including failed renders, so the bar reaches 100%.
+        done = done + 1
+        progressScope:setPortionComplete(done, nPhotos)
+        if done == 1 or done % 10 == 0 or done == nPhotos then
+            log:info('Publish progress: ' .. done .. '/' .. nPhotos
+                .. ' (' .. math.floor(done * 100 / nPhotos) .. '%)')
         end
     end
     return failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto

--- a/immich-plugin.lrplugin/PublishTask.lua
+++ b/immich-plugin.lrplugin/PublishTask.lua
@@ -45,22 +45,15 @@ local function addAssetToPublishAlbum(immich, albumCreationStrategy, albumId, al
 end
 
 --------------------------------------------------------------------------------
--- Process one photo group in DNG+JPG publish flow. Mutates failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto.
+-- Process one photo group in original+export publish flow. Mutates failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto.
 local function processPublishOnePhotoGroup(immich, lid, items, albumCreationStrategy, albumId, albumAssetIds,
     failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto)
     if not items or not items[1] then return end
     local photo = items[1].photo
     local filename = photo:getFormattedMetadata("fileName")
     local dateCreated = photo:getFormattedMetadata("dateCreated")
-    local hasRaw, hasJpeg = false, false
-    for _, item in ipairs(items) do
-        if item.fileType == "raw" then hasRaw = true end
-        if item.fileType == "jpeg" then hasJpeg = true end
-    end
-    local shouldStackDngJpg = hasRaw and hasJpeg
-
-    if shouldStackDngJpg and #items >= 2 then
-        UploadHelpers.sortDngJpgItems(items)
+    if #items >= 2 then
+        UploadHelpers.sortOriginalExportItems(items)
         local assetIds = {}
         local primaryId = nil
         for _, item in ipairs(items) do
@@ -79,7 +72,7 @@ local function processPublishOnePhotoGroup(immich, lid, items, albumCreationStra
         end
         if #assetIds >= 2 and primaryId then
             if not immich:createStack(assetIds) then
-                table.insert(stackWarnings, filename .. ": Failed to create DNG+JPG stack")
+                table.insert(stackWarnings, filename .. ": Failed to create original+export stack")
             end
         end
         if primaryId then
@@ -111,18 +104,41 @@ local function processPublishOnePhotoGroup(immich, lid, items, albumCreationStra
 end
 
 --------------------------------------------------------------------------------
-local function processPublishStackDngJpgRenditions(immich, exportContext, progressScope, exportParams,
+-- Original+export flow: accumulate renditions per photo, flush each group as soon as
+-- both renditions are ready. This avoids buffering all renders before any upload starts.
+local function processPublishStackOriginalExportRenditions(immich, exportContext, progressScope, exportParams,
     albumCreationStrategy, albumId, albumAssetIds)
     local failures, stackWarnings = {}, {}
     local atLeastSomeSuccess = { false }
     local exportedPrimaryByPhoto = {}
-    local collected = UploadHelpers.collectRenditions(exportContext, progressScope)
-    if not collected then return failures, stackWarnings, atLeastSomeSuccess[1], exportedPrimaryByPhoto end
-    local byPhoto = UploadHelpers.groupByPhoto(collected)
-    for lid, items in pairs(byPhoto) do
+    local accumulator = {}
+    for _, rendition in exportContext:renditions { stopIfCanceled = true } do
         if progressScope:isCanceled() then break end
-        processPublishOnePhotoGroup(immich, lid, items, albumCreationStrategy, albumId, albumAssetIds,
-            failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto)
+        local success, pathOrMessage = rendition:waitForRender()
+        if progressScope:isCanceled() then break end
+        if success then
+            local lid = rendition.photo.localIdentifier
+            if not accumulator[lid] then accumulator[lid] = {} end
+            table.insert(accumulator[lid], {
+                path = pathOrMessage,
+                photo = rendition.photo,
+                rendition = rendition,
+                ext = util.getExtension(pathOrMessage),
+            })
+            -- Both renditions for this photo are ready: upload and stack immediately.
+            if #accumulator[lid] == 2 then
+                processPublishOnePhotoGroup(immich, lid, accumulator[lid], albumCreationStrategy, albumId, albumAssetIds,
+                    failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto)
+                accumulator[lid] = nil
+            end
+        end
+    end
+    -- Flush any incomplete groups (one rendition failed to render or publish was canceled).
+    for lid, items in pairs(accumulator) do
+        if not progressScope:isCanceled() then
+            processPublishOnePhotoGroup(immich, lid, items, albumCreationStrategy, albumId, albumAssetIds,
+                failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto)
+        end
     end
     return failures, stackWarnings, atLeastSomeSuccess[1], exportedPrimaryByPhoto
 end
@@ -175,8 +191,8 @@ end
 local function runPublishExport(immich, exportContext, progressScope, exportParams,
     albumCreationStrategy, albumId, albumAssetIds)
     local failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto
-    if exportParams.stackDngJpg then
-        failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto = processPublishStackDngJpgRenditions(
+    if exportParams.stackOriginalExport then
+        failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto = processPublishStackOriginalExportRenditions(
             immich, exportContext, progressScope, exportParams, albumCreationStrategy, albumId, albumAssetIds)
     else
         failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto = processPublishSingleRenditionRenditions(

--- a/immich-plugin.lrplugin/PublishTask.lua
+++ b/immich-plugin.lrplugin/PublishTask.lua
@@ -63,8 +63,8 @@ local function processPublishOnePhotoGroup(immich, lid, items, albumCreationStra
         UploadHelpers.sortDngJpgItems(items)
         local assetIds = {}
         local primaryId = nil
-        for i, item in ipairs(items) do
-            local deviceAssetId = lid .. "_" .. tostring(i)
+        for _, item in ipairs(items) do
+            local deviceAssetId = lid .. "_" .. util.getExtension(item.path)
             local id = StackManager.uploadOneAssetOrReplace(immich, item.path, deviceAssetId, filename, dateCreated)
             UploadHelpers.safeDeleteTempFile(item.path)
             if not id then

--- a/immich-plugin.lrplugin/PublishTask.lua
+++ b/immich-plugin.lrplugin/PublishTask.lua
@@ -70,6 +70,7 @@ local function processPublishOnePhotoGroup(immich, lid, items, albumCreationStra
                 if primaryId == nil then primaryId = id end
                 item.rendition:recordPublishedPhotoId(id)
                 item.rendition:recordPublishedPhotoUrl(immich:getAssetUrl(id))
+                log:info('original+export [' .. filename .. ']: ' .. deviceAssetId .. ' -> ' .. id)
             end
         end
         if #assetIds >= 2 and primaryId then
@@ -83,11 +84,18 @@ local function processPublishOnePhotoGroup(immich, lid, items, albumCreationStra
                 photo:getFormattedMetadata("folderName"))
         end
     elseif #items == 1 then
-        -- One rendition arrived (the other failed to render or was not expected for this photo/mode).
-        -- Use isOriginal to determine the role: original copy (_orig) vs rendered export (_export).
+        -- One rendition arrived. Since LR_exportOriginalFile is never set, Lightroom always
+        -- delivers the rendered export (never an original-copy rendition). The isOriginal flag
+        -- is a false positive for same-extension pairs (e.g. JPG→JPG, TIF→TIF): the rendered
+        -- export and the source share the same extension, but the rendition is still the edited
+        -- export. Always treat the single rendition as the export.
+        -- Do NOT upload the disk original: assets uploaded outside of recordPublishedPhotoId
+        -- cannot be tracked by Lightroom and become orphans when the photo is removed from the
+        -- publish collection (deletePhotosFromPublishedCollection only cleans up assets
+        -- registered via recordPublishedPhotoId). Warn instead.
         local item = items[1]
-        local isOrig = item.isOriginal == true
-        local deviceAssetId = lid .. (isOrig and "_orig" or "_export")
+        local deviceAssetId = lid .. "_export"
+        log:info('original+export [' .. filename .. ']: single rendition, uploading as export (' .. deviceAssetId .. ')')
         local id = StackManager.uploadOneAssetOrReplace(immich, item.path, deviceAssetId, filename, dateCreated)
         UploadHelpers.safeDeleteTempFile(item.path)
         if not id then
@@ -97,14 +105,7 @@ local function processPublishOnePhotoGroup(immich, lid, items, albumCreationStra
             local primaryId = id
             item.rendition:recordPublishedPhotoId(id)
             item.rendition:recordPublishedPhotoUrl(immich:getAssetUrl(id))
-            if not isOrig then
-                -- Export rendition arrived but original rendition did not. Do NOT upload the disk
-                -- original here: assets uploaded outside of rendition:recordPublishedPhotoId cannot
-                -- be tracked by Lightroom and will become orphans when the photo is later removed
-                -- from the publish collection (deletePhotosFromPublishedCollection only cleans up
-                -- assets registered via recordPublishedPhotoId). Warn instead.
-                table.insert(stackWarnings, filename .. ": only export rendition available; original not uploaded to avoid untracked orphan in Immich")
-            end
+            table.insert(stackWarnings, filename .. ": only export rendition available; original not uploaded to avoid untracked orphan in Immich")
             exportedPrimaryByPhoto[photo.localIdentifier] = { assetId = primaryId, photo = photo }
             addAssetToPublishAlbum(immich, albumCreationStrategy, albumId, albumAssetIds, primaryId,
                 photo:getFormattedMetadata("folderName"))
@@ -113,14 +114,17 @@ local function processPublishOnePhotoGroup(immich, lid, items, albumCreationStra
 end
 
 --------------------------------------------------------------------------------
--- Original+export flow: accumulate renditions per photo, flush each group as soon as
--- both renditions are ready. This avoids buffering all renders before any upload starts.
-local function processPublishStackOriginalExportRenditions(immich, exportContext, progressScope,
+-- Original+export flow: process each rendition immediately as it arrives, keeping
+-- renders and uploads interleaved so the Lightroom progress bar advances
+-- proportionally to real work done. LR_exportOriginalFile is never set, so LR
+-- always delivers exactly one rendition per photo; the disk original is fetched
+-- inside processPublishOnePhotoGroup (or skipped for orphan safety in publish mode).
+local function processPublishStackOriginalExportRenditions(immich, exportContext, progressScope, nPhotos,
     albumCreationStrategy, albumId, albumAssetIds)
     local failures, stackWarnings = {}, {}
     local atLeastSomeSuccess = { false }
     local exportedPrimaryByPhoto = {}
-    local accumulator = {}
+    local done = 0
     for _, rendition in exportContext:renditions { stopIfCanceled = true } do
         if progressScope:isCanceled() then break end
         local success, pathOrMessage = rendition:waitForRender()
@@ -128,42 +132,37 @@ local function processPublishStackOriginalExportRenditions(immich, exportContext
         if success then
             -- Use stable device ID (UUID when available) so deviceAssetIds survive catalog re-imports.
             local lid = util.getPhotoDeviceId(rendition.photo) or rendition.photo.localIdentifier
-            if not accumulator[lid] then accumulator[lid] = {} end
             local srcPath = StackManager.getOriginalFilePath(rendition.photo)
             local srcExt = srcPath and util.getExtension(srcPath) or ""
             local itemExt = util.getExtension(pathOrMessage)
-            table.insert(accumulator[lid], {
+            local item = {
                 path = pathOrMessage,
                 photo = rendition.photo,
                 rendition = rendition,
                 ext = itemExt,
                 isOriginal = srcExt ~= "" and itemExt == srcExt,
-                insertionOrder = #accumulator[lid],  -- 0-based; used as stable sort tiebreaker
-            })
-            -- Both renditions for this photo are ready: upload and stack immediately.
-            if #accumulator[lid] == 2 then
-                processPublishOnePhotoGroup(immich, lid, accumulator[lid], albumCreationStrategy, albumId, albumAssetIds,
-                    failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto)
-                accumulator[lid] = nil
-            end
-        end
-    end
-    -- Flush any incomplete groups (one rendition failed to render or publish was canceled).
-    for lid, items in pairs(accumulator) do
-        if not progressScope:isCanceled() then
-            processPublishOnePhotoGroup(immich, lid, items, albumCreationStrategy, albumId, albumAssetIds,
+                insertionOrder = 0,
+            }
+            processPublishOnePhotoGroup(immich, lid, { item }, albumCreationStrategy, albumId, albumAssetIds,
                 failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto)
+            done = done + 1
+            progressScope:setPortionComplete(done, nPhotos)
+            if done == 1 or done % 10 == 0 or done == nPhotos then
+                log:info('Publish progress: ' .. done .. '/' .. nPhotos
+                    .. ' (' .. math.floor(done * 100 / nPhotos) .. '%)')
+            end
         end
     end
     return failures, stackWarnings, atLeastSomeSuccess[1], exportedPrimaryByPhoto
 end
 
 --------------------------------------------------------------------------------
-local function processPublishSingleRenditionRenditions(immich, exportContext, progressScope, exportParams,
+local function processPublishSingleRenditionRenditions(immich, exportContext, progressScope, nPhotos, exportParams,
     albumCreationStrategy, albumId, albumAssetIds)
     local failures, stackWarnings = {}, {}
     local atLeastSomeSuccess = false
     local exportedPrimaryByPhoto = {}
+    local done = 0
     for _, rendition in exportContext:renditions { stopIfCanceled = true } do
         local success, pathOrMessage = rendition:waitForRender()
         if progressScope:isCanceled() then break end
@@ -197,21 +196,27 @@ local function processPublishSingleRenditionRenditions(immich, exportContext, pr
                 end
             end
             UploadHelpers.safeDeleteTempFile(pathOrMessage)
+            done = done + 1
+            progressScope:setPortionComplete(done, nPhotos)
+            if done == 1 or done % 10 == 0 or done == nPhotos then
+                log:info('Publish progress: ' .. done .. '/' .. nPhotos
+                    .. ' (' .. math.floor(done * 100 / nPhotos) .. '%)')
+            end
         end
     end
     return failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto
 end
 
 --------------------------------------------------------------------------------
-local function runPublishExport(immich, exportContext, progressScope, exportParams,
+local function runPublishExport(immich, exportContext, progressScope, nPhotos, exportParams,
     albumCreationStrategy, albumId, albumAssetIds)
     local failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto
     if exportParams.stackOriginalExport then
         failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto = processPublishStackOriginalExportRenditions(
-            immich, exportContext, progressScope, albumCreationStrategy, albumId, albumAssetIds)
+            immich, exportContext, progressScope, nPhotos, albumCreationStrategy, albumId, albumAssetIds)
     else
         failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto = processPublishSingleRenditionRenditions(
-            immich, exportContext, progressScope, exportParams, albumCreationStrategy, albumId, albumAssetIds)
+            immich, exportContext, progressScope, nPhotos, exportParams, albumCreationStrategy, albumId, albumAssetIds)
     end
     if exportParams.stackLrStacks and next(exportedPrimaryByPhoto) then
         UploadHelpers.applyLrStacksInImmich(immich, exportedPrimaryByPhoto, stackWarnings)
@@ -228,14 +233,27 @@ function PublishTask.processRenderedPhotos(functionContext, exportContext)
     local albumCreationStrategy, albumId, albumAssetIds = resolvePublishAlbum(immich, exportContext)
 
     local nPhotos = exportSession:countRenditions()
+    log:info('=== Publish START: ' .. nPhotos .. ' photos | url=' .. tostring(exportParams.url)
+        .. ' | stackOriginalExport=' .. tostring(exportParams.stackOriginalExport)
+        .. ' | stackLrStacks=' .. tostring(exportParams.stackLrStacks)
+        .. ' | albumCreationStrategy=' .. tostring(albumCreationStrategy) .. ' ===')
+
     local progressTitle = (prefs and prefs.url and prefs.url ~= "") and prefs.url or "Immich"
-    local progressScope = exportContext:configureProgress {
-        title = util.buildSimpleUploadProgressTitle(nPhotos, "Publishing", progressTitle)
+    -- Use LrProgressScope tied to functionContext rather than exportContext:configureProgress.
+    -- configureProgress creates a scope managed by LR's render pipeline, which closes the bar
+    -- when rendering completes — potentially long before all uploads are done. LrProgressScope
+    -- with functionContext stays alive until processRenderedPhotos returns, and is not advanced
+    -- by LR's render thread, eliminating both early-close and forward→0→return race conditions.
+    local progressScope = LrProgressScope {
+        title = util.buildSimpleUploadProgressTitle(nPhotos, "Publishing", progressTitle),
+        functionContext = functionContext,
     }
 
     local failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto = runPublishExport(
-        immich, exportContext, progressScope, exportParams, albumCreationStrategy, albumId, albumAssetIds)
+        immich, exportContext, progressScope, nPhotos, exportParams, albumCreationStrategy, albumId, albumAssetIds)
 
+    log:info('=== Publish DONE: ' .. nPhotos .. ' photos | failures=' .. #failures
+        .. ' | warnings=' .. #stackWarnings .. ' ===')
     util.reportUploadFailuresAndWarnings(failures, stackWarnings)
 end
 

--- a/immich-plugin.lrplugin/PublishTask.lua
+++ b/immich-plugin.lrplugin/PublishTask.lua
@@ -85,10 +85,8 @@ local function processPublishOnePhotoGroup(immich, lid, items, albumCreationStra
         end
     elseif #items == 1 then
         -- One rendition arrived. Since LR_exportOriginalFile is never set, Lightroom always
-        -- delivers the rendered export (never an original-copy rendition). The isOriginal flag
-        -- is a false positive for same-extension pairs (e.g. JPG→JPG, TIF→TIF): the rendered
-        -- export and the source share the same extension, but the rendition is still the edited
-        -- export. Always treat the single rendition as the export.
+        -- delivers the rendered export (never an original-copy rendition), so item.role = "export".
+        -- Always treat the single rendition as the export.
         -- Do NOT upload the disk original: assets uploaded outside of recordPublishedPhotoId
         -- cannot be tracked by Lightroom and become orphans when the photo is removed from the
         -- publish collection (deletePhotosFromPublishedCollection only cleans up assets
@@ -132,25 +130,23 @@ local function processPublishStackOriginalExportRenditions(immich, exportContext
         if success then
             -- Use stable device ID (UUID when available) so deviceAssetIds survive catalog re-imports.
             local lid = util.getPhotoDeviceId(rendition.photo) or rendition.photo.localIdentifier
-            local srcPath = StackManager.getOriginalFilePath(rendition.photo)
-            local srcExt = srcPath and util.getExtension(srcPath) or ""
-            local itemExt = util.getExtension(pathOrMessage)
+            -- role = "export": LR_exportOriginalFile is never set, so LR always delivers the
+            -- rendered export (never an original-copy rendition), regardless of file extension.
             local item = {
                 path = pathOrMessage,
                 photo = rendition.photo,
                 rendition = rendition,
-                ext = itemExt,
-                isOriginal = srcExt ~= "" and itemExt == srcExt,
-                insertionOrder = 0,
+                role = "export",
             }
             processPublishOnePhotoGroup(immich, lid, { item }, albumCreationStrategy, albumId, albumAssetIds,
                 failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto)
-            done = done + 1
-            progressScope:setPortionComplete(done, nPhotos)
-            if done == 1 or done % 10 == 0 or done == nPhotos then
-                log:info('Publish progress: ' .. done .. '/' .. nPhotos
-                    .. ' (' .. math.floor(done * 100 / nPhotos) .. '%)')
-            end
+        end
+        -- Advance progress for every rendition, including failed renders, so the bar reaches 100%.
+        done = done + 1
+        progressScope:setPortionComplete(done, nPhotos)
+        if done == 1 or done % 10 == 0 or done == nPhotos then
+            log:info('Publish progress: ' .. done .. '/' .. nPhotos
+                .. ' (' .. math.floor(done * 100 / nPhotos) .. '%)')
         end
     end
     return failures, stackWarnings, atLeastSomeSuccess[1], exportedPrimaryByPhoto
@@ -251,6 +247,7 @@ function PublishTask.processRenderedPhotos(functionContext, exportContext)
 
     local failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto = runPublishExport(
         immich, exportContext, progressScope, nPhotos, exportParams, albumCreationStrategy, albumId, albumAssetIds)
+    progressScope:done()
 
     log:info('=== Publish DONE: ' .. nPhotos .. ' photos | failures=' .. #failures
         .. ' | warnings=' .. #stackWarnings .. ' ===')

--- a/immich-plugin.lrplugin/StackManager.lua
+++ b/immich-plugin.lrplugin/StackManager.lua
@@ -31,7 +31,7 @@ end
 
 --------------------------------------------------------------------------------
 -- Check if a photo has been edited in Lightroom.
--- When a cache is provided it is used exclusively — no fallback queries are run.
+-- When a cache is provided it is used exclusively; no fallback queries are made.
 -- When no cache is provided, falls back to direct catalog queries.
 function StackManager.hasEdits(photo, editedPhotosCache)
     -- If we have a cache, use it exclusively (no fallback needed — cache was built from same queries)

--- a/immich-plugin.lrplugin/StackManager.lua
+++ b/immich-plugin.lrplugin/StackManager.lua
@@ -17,16 +17,6 @@ log:enable("logfile")
 
 StackManager = {}
 
---------------------------------------------------------------------------------
--- File type for DNG+JPG stacking: 'raw', 'jpeg', or 'other'
-local RAW_EXT = { dng = true, nef = true, nefw = true, nrw = true, arw = true, cr2 = true, cr3 = true, crw = true, orf = true, raf = true, rw2 = true, pef = true, srw = true, erf = true, dcr = true, raw = true, ['3fr'] = true, x3f = true, mrw = true, rwl = true }
-
-function StackManager.getFileType(path)
-    local ext = util.getExtension(path)
-    if ext == "jpg" or ext == "jpeg" then return "jpeg" end
-    if RAW_EXT[ext] then return "raw" end
-    return "other"
-end
 
 --------------------------------------------------------------------------------
 -- Upload one asset or replace existing; returns Immich asset id or nil
@@ -40,8 +30,9 @@ function StackManager.uploadOneAssetOrReplace(immich, path, deviceAssetId, filen
 end
 
 --------------------------------------------------------------------------------
--- Check if a photo has been edited in Lightroom
--- Primarily uses cache lookup, with fallback to individual checks
+-- Check if a photo has been edited in Lightroom.
+-- When a cache is provided it is used exclusively — no fallback queries are run.
+-- When no cache is provided, falls back to direct catalog queries.
 function StackManager.hasEdits(photo, editedPhotosCache)
     -- If we have a cache, use it exclusively (no fallback needed — cache was built from same queries)
     if editedPhotosCache then

--- a/immich-plugin.lrplugin/StackManager.lua
+++ b/immich-plugin.lrplugin/StackManager.lua
@@ -43,15 +43,11 @@ end
 -- Check if a photo has been edited in Lightroom
 -- Primarily uses cache lookup, with fallback to individual checks
 function StackManager.hasEdits(photo, editedPhotosCache)
-    -- If we have a cache, use it for fast lookup first
+    -- If we have a cache, use it exclusively (no fallback needed — cache was built from same queries)
     if editedPhotosCache then
-        local hasEdits = (editedPhotosCache[photo.localIdentifier] ~= nil)
-        if hasEdits then
-            log:trace("Photo " .. photo.localIdentifier .. " has edits (cache): " .. tostring(hasEdits))
-            return true
-        end
+        return editedPhotosCache[photo.localIdentifier] ~= nil
     end
-    
+
     -- Fallback: check directly using hasAdjustments criterion
     local catalog = LrApplication.activeCatalog()
     if not catalog then

--- a/immich-plugin.lrplugin/StackManager.lua
+++ b/immich-plugin.lrplugin/StackManager.lua
@@ -11,10 +11,6 @@ This module provides functionality to:
 
 require "ImmichAPI"
 
--- Initialize logging
-local log = LrLogger('ImmichPlugin')
-log:enable("logfile")
-
 StackManager = {}
 
 

--- a/immich-plugin.lrplugin/UploadHelpers.lua
+++ b/immich-plugin.lrplugin/UploadHelpers.lua
@@ -28,22 +28,14 @@ end
 
 --------------------------------------------------------------------------------
 -- Original+export sort order: rendered export first (primary in Immich), original second.
--- Role is determined by the isOriginal flag set at item creation time (extension-based).
--- insertionOrder is used as a stable tiebreaker because Lua's table.sort is not stable:
--- returning false for equal elements does not preserve insertion order.
--- For same-extension pairs (e.g. JPEG→JPEG) where both have isOriginal=true, the tiebreaker
--- uses HIGHER insertionOrder first. Lightroom renders the original copy first (insertionOrder=0)
--- and the edited export second (insertionOrder=1), so the export (insertionOrder=1) sorts first
--- and becomes items[1] (primary in Immich), as intended. IDs are always distinct and consistent
--- across re-exports.
+-- Items must carry an explicit role field: "export" or "orig".
+-- Using an explicit role avoids ambiguity for same-extension pairs (e.g. JPEG→JPEG)
+-- where extension-based detection cannot distinguish the rendered export from the original.
 function UploadHelpers.sortOriginalExportItems(items)
     table.sort(items, function(a, b)
-        local aIsOrig = a.isOriginal == true
-        local bIsOrig = b.isOriginal == true
-        if aIsOrig ~= bIsOrig then
-            return not aIsOrig  -- export (non-original) sorts first
-        end
-        return (a.insertionOrder or 0) > (b.insertionOrder or 0)  -- higher insertionOrder = rendered export = sorts first
+        local aIsExport = a.role == "export"
+        local bIsExport = b.role == "export"
+        return aIsExport and not bIsExport  -- export sorts first; equal roles stay in place
     end)
 end
 

--- a/immich-plugin.lrplugin/UploadHelpers.lua
+++ b/immich-plugin.lrplugin/UploadHelpers.lua
@@ -2,7 +2,7 @@
 UploadHelpers.lua - Shared upload logic for Export and Publish
 
 Provides:
-- Collecting and grouping renditions (DNG+JPG flow)
+- Collecting and grouping renditions (original+export flow)
 - Preserving Lightroom stacks in Immich
 - Safe temporary file deletion (ensures cleanup on error or cancel)
 ]]
@@ -28,7 +28,7 @@ end
 
 --------------------------------------------------------------------------------
 -- Collect all renditions from exportContext into an array of
--- { path, photo, rendition, ext, fileType }. Stops if progressScope is canceled.
+-- { path, photo, rendition, ext }. Stops if progressScope is canceled.
 -- Returns collected array, or nil if canceled.
 function UploadHelpers.collectRenditions(exportContext, progressScope)
     local collected = {}
@@ -46,7 +46,6 @@ function UploadHelpers.collectRenditions(exportContext, progressScope)
                 photo = rendition.photo,
                 rendition = rendition,
                 ext = util.getExtension(pathOrMessage),
-                fileType = StackManager.getFileType(pathOrMessage),
             })
         end
     end
@@ -66,11 +65,16 @@ function UploadHelpers.groupByPhoto(collected)
 end
 
 --------------------------------------------------------------------------------
--- DNG+JPG sort order: jpeg first (primary), then raw, then other.
-function UploadHelpers.sortDngJpgItems(items)
+-- Original+export sort order: rendered export first (primary in Immich), original second.
+-- The original is identified by comparing its path to the source file on disk.
+function UploadHelpers.sortOriginalExportItems(items)
     table.sort(items, function(a, b)
-        local order = { jpeg = 1, raw = 2, other = 3 }
-        return (order[a.fileType] or 3) < (order[b.fileType] or 3)
+        local aIsOriginal = (a.path == StackManager.getOriginalFilePath(a.photo))
+        local bIsOriginal = (b.path == StackManager.getOriginalFilePath(b.photo))
+        if aIsOriginal ~= bIsOriginal then
+            return not aIsOriginal  -- export (non-original) sorts first
+        end
+        return false  -- preserve order for items of the same kind
     end)
 end
 

--- a/immich-plugin.lrplugin/UploadHelpers.lua
+++ b/immich-plugin.lrplugin/UploadHelpers.lua
@@ -66,15 +66,22 @@ end
 
 --------------------------------------------------------------------------------
 -- Original+export sort order: rendered export first (primary in Immich), original second.
--- The original is identified by comparing its path to the source file on disk.
+-- Role is determined by the isOriginal flag set at item creation time (extension-based).
+-- insertionOrder is used as a stable tiebreaker because Lua's table.sort is not stable:
+-- returning false for equal elements does not preserve insertion order.
+-- For same-extension pairs (e.g. JPEG→JPEG) where both have isOriginal=true, insertion
+-- order is preserved (original copy arrives first, rendered export arrives second), so
+-- items[1] will be the original. The caller assigns _export/_orig by index, so the
+-- label is semantically wrong for same-ext pairs but the IDs are always distinct and
+-- consistent across re-exports.
 function UploadHelpers.sortOriginalExportItems(items)
     table.sort(items, function(a, b)
-        local aIsOriginal = (a.path == StackManager.getOriginalFilePath(a.photo))
-        local bIsOriginal = (b.path == StackManager.getOriginalFilePath(b.photo))
-        if aIsOriginal ~= bIsOriginal then
-            return not aIsOriginal  -- export (non-original) sorts first
+        local aIsOrig = a.isOriginal == true
+        local bIsOrig = b.isOriginal == true
+        if aIsOrig ~= bIsOrig then
+            return not aIsOrig  -- export (non-original) sorts first
         end
-        return false  -- preserve order for items of the same kind
+        return (a.insertionOrder or 0) < (b.insertionOrder or 0)  -- stable tiebreaker
     end)
 end
 

--- a/immich-plugin.lrplugin/UploadHelpers.lua
+++ b/immich-plugin.lrplugin/UploadHelpers.lua
@@ -35,7 +35,7 @@ function UploadHelpers.sortOriginalExportItems(items)
     table.sort(items, function(a, b)
         local aIsExport = a.role == "export"
         local bIsExport = b.role == "export"
-        return aIsExport and not bIsExport  -- export sorts first; equal roles stay in place
+        return aIsExport and not bIsExport  -- exports before originals
     end)
 end
 

--- a/immich-plugin.lrplugin/UploadHelpers.lua
+++ b/immich-plugin.lrplugin/UploadHelpers.lua
@@ -69,11 +69,11 @@ end
 -- Role is determined by the isOriginal flag set at item creation time (extension-based).
 -- insertionOrder is used as a stable tiebreaker because Lua's table.sort is not stable:
 -- returning false for equal elements does not preserve insertion order.
--- For same-extension pairs (e.g. JPEG→JPEG) where both have isOriginal=true, insertion
--- order is preserved (original copy arrives first, rendered export arrives second), so
--- items[1] will be the original. The caller assigns _export/_orig by index, so the
--- label is semantically wrong for same-ext pairs but the IDs are always distinct and
--- consistent across re-exports.
+-- For same-extension pairs (e.g. JPEG→JPEG) where both have isOriginal=true, the tiebreaker
+-- uses HIGHER insertionOrder first. Lightroom renders the original copy first (insertionOrder=0)
+-- and the edited export second (insertionOrder=1), so the export (insertionOrder=1) sorts first
+-- and becomes items[1] (primary in Immich), as intended. IDs are always distinct and consistent
+-- across re-exports.
 function UploadHelpers.sortOriginalExportItems(items)
     table.sort(items, function(a, b)
         local aIsOrig = a.isOriginal == true
@@ -81,7 +81,7 @@ function UploadHelpers.sortOriginalExportItems(items)
         if aIsOrig ~= bIsOrig then
             return not aIsOrig  -- export (non-original) sorts first
         end
-        return (a.insertionOrder or 0) < (b.insertionOrder or 0)  -- stable tiebreaker
+        return (a.insertionOrder or 0) > (b.insertionOrder or 0)  -- higher insertionOrder = rendered export = sorts first
     end)
 end
 

--- a/immich-plugin.lrplugin/UploadHelpers.lua
+++ b/immich-plugin.lrplugin/UploadHelpers.lua
@@ -2,7 +2,7 @@
 UploadHelpers.lua - Shared upload logic for Export and Publish
 
 Provides:
-- Collecting and grouping renditions (original+export flow)
+- Sorting original+export rendition pairs for correct Immich stack ordering
 - Preserving Lightroom stacks in Immich
 - Safe temporary file deletion (ensures cleanup on error or cancel)
 ]]
@@ -24,44 +24,6 @@ function UploadHelpers.safeDeleteTempFile(path)
     if not ok and log and log.warn then
         log:warn("UploadHelpers: could not delete temp file: " .. tostring(path) .. " - " .. tostring(err))
     end
-end
-
---------------------------------------------------------------------------------
--- Collect all renditions from exportContext into an array of
--- { path, photo, rendition, ext }. Stops if progressScope is canceled.
--- Returns collected array, or nil if canceled.
-function UploadHelpers.collectRenditions(exportContext, progressScope)
-    local collected = {}
-    for _, rendition in exportContext:renditions { stopIfCanceled = true } do
-        if progressScope and progressScope:isCanceled() then
-            return nil
-        end
-        local success, pathOrMessage = rendition:waitForRender()
-        if progressScope and progressScope:isCanceled() then
-            return nil
-        end
-        if success then
-            table.insert(collected, {
-                path = pathOrMessage,
-                photo = rendition.photo,
-                rendition = rendition,
-                ext = util.getExtension(pathOrMessage),
-            })
-        end
-    end
-    return collected
-end
-
---------------------------------------------------------------------------------
--- Group collected items by photo localIdentifier. Returns map lid -> array of items.
-function UploadHelpers.groupByPhoto(collected)
-    local byPhoto = {}
-    for _, item in ipairs(collected) do
-        local lid = item.photo.localIdentifier
-        if not byPhoto[lid] then byPhoto[lid] = {} end
-        table.insert(byPhoto[lid], item)
-    end
-    return byPhoto
 end
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
I asked Claude to help me, and it identified the root issue, plus some other issues that may be of general performance and robustness benefit.
I am not a LUA or LR plugin expert, I relied on Claude to help me analyze and troubleshoot, so please double check.
I did download the v15.2 LR SDK and docs and gave that to Claude as reference.

After testing showed the initial fixes working, I got tired of manually reviewing Copilot comments, and I had Claude automatically respond to Copilot's reviews, and the two of them went back and forth until they were both happy, weird.

See [PR.md](https://github.com/ptr727/bmachek-lrc-immich-plugin/blob/claude/PR.md) for analysis and details of the change.

Probably better if you cherry pick changes vs. just merge as is, especially since the strings were changed and would need to be translated.
