### PR TITLE
feat: sync capture date and keywords to Immich for videos

### DIFF
--- a/immich-plugin.lrplugin/ExportTask.lua
+++ b/immich-plugin.lrplugin/ExportTask.lua
@@ -648,6 +648,7 @@ local function runExport(
     if exportParams.stackLrStacks and next(exportedPrimaryByPhoto) then
         UploadHelpers.applyLrStacksInImmich(immich, exportedPrimaryByPhoto, stackWarnings)
     end
+    UploadHelpers.applyVideoMetadataForAll(immich, exportedPrimaryByPhoto)
     return failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto
 end
 

--- a/immich-plugin.lrplugin/ImmichAPI.lua
+++ b/immich-plugin.lrplugin/ImmichAPI.lua
@@ -483,6 +483,94 @@ function ImmichAPI:setAssetVisibility(assetId, visibility)
     return true
 end
 
+-- Set the capture date (dateTimeOriginal) on an existing asset, mirroring the
+-- web UI's date editor. Used to push Lightroom's edited capture time for assets
+-- Immich cannot read it from the file (videos). Immich persists this to a
+-- sidecar, so it survives later metadata re-extraction.
+function ImmichAPI:setAssetDate(assetId, isoDate)
+    if util.nilOrEmpty(assetId) or util.nilOrEmpty(isoDate) then
+        log:warn("setAssetDate: assetId or date empty")
+        return false
+    end
+    local body = { dateTimeOriginal = isoDate }
+    local parsedResponse = self:doCustomRequest("PUT", "/assets/" .. assetId, body)
+    if parsedResponse == nil then
+        log:error("setAssetDate: failed to set date " .. tostring(isoDate) .. " on " .. assetId)
+        return false
+    end
+    log:trace("setAssetDate: " .. assetId .. " -> " .. tostring(isoDate))
+    return true
+end
+
+-- Upsert tags by value (supports nested "parent/child"). Returns the array of
+-- tag objects ({ id, name, value }) on success, or nil.
+function ImmichAPI:upsertTags(tagNames)
+    if type(tagNames) ~= "table" or #tagNames == 0 then
+        return nil
+    end
+    local body = { tags = tagNames }
+    local parsedResponse = self:doCustomRequest("PUT", "/tags", body)
+    if parsedResponse == nil then
+        log:error("upsertTags: failed to upsert tags")
+        return nil
+    end
+    return parsedResponse
+end
+
+-- Assign already-upserted tag ids to a single asset (bulk endpoint).
+function ImmichAPI:assignTagsToAsset(tagIds, assetId)
+    if type(tagIds) ~= "table" or #tagIds == 0 or util.nilOrEmpty(assetId) then
+        return false
+    end
+    local body = { tagIds = tagIds, assetIds = { assetId } }
+    local parsedResponse = self:doCustomRequest("PUT", "/tags/assets", body)
+    if parsedResponse == nil then
+        log:error("assignTagsToAsset: failed to assign tags to " .. assetId)
+        return false
+    end
+    log:trace("assignTagsToAsset: " .. #tagIds .. " tag(s) -> " .. assetId)
+    return true
+end
+
+-- Poll until Immich has finished ingesting the asset (thumbnail generated).
+-- A freshly uploaded video is probed and thumbnailed asynchronously; mutating its
+-- metadata before that completes races the ingest pipeline and leaves the
+-- thumbnail in an error state. Returns true once ready, false on timeout.
+function ImmichAPI:waitForAssetReady(assetId, maxSeconds)
+    if util.nilOrEmpty(assetId) then
+        return false
+    end
+    local limit = maxSeconds or 30
+    local waited = 0
+    while waited < limit do
+        local asset = self:doGetRequest("/assets/" .. assetId)
+        if asset ~= nil and type(asset.thumbhash) == "string" and asset.thumbhash ~= "" then
+            return true
+        end
+        LrTasks.sleep(1)
+        waited = waited + 1
+    end
+    log:warn("waitForAssetReady: timed out after " .. limit .. "s waiting for " .. assetId)
+    return false
+end
+
+-- Queue a thumbnail regeneration for an asset (same action as the web UI's
+-- "Regenerate thumbnails"). Used after a metadata change so a video whose
+-- thumbnail was invalidated recovers on its own. Returns true on success.
+function ImmichAPI:regenerateThumbnail(assetId)
+    if util.nilOrEmpty(assetId) then
+        return false
+    end
+    local body = { assetIds = { assetId }, name = "regenerate-thumbnail" }
+    local parsedResponse = self:doCustomRequest("POST", "/assets/jobs", body)
+    if parsedResponse == nil then
+        log:error("regenerateThumbnail: failed to queue for " .. assetId)
+        return false
+    end
+    log:trace("regenerateThumbnail: queued for " .. assetId)
+    return true
+end
+
 function ImmichAPI:copyAssetMetadata(sourceAssetId, targetAssetId)
     if util.nilOrEmpty(sourceAssetId) then
         ErrorHandler.handleError(

--- a/immich-plugin.lrplugin/PublishTask.lua
+++ b/immich-plugin.lrplugin/PublishTask.lua
@@ -368,6 +368,7 @@ local function runPublishExport(
     if exportParams.stackLrStacks and next(exportedPrimaryByPhoto) then
         UploadHelpers.applyLrStacksInImmich(immich, exportedPrimaryByPhoto, stackWarnings)
     end
+    UploadHelpers.applyVideoMetadataForAll(immich, exportedPrimaryByPhoto)
     return failures, stackWarnings, atLeastSomeSuccess, exportedPrimaryByPhoto
 end
 

--- a/immich-plugin.lrplugin/UploadHelpers.lua
+++ b/immich-plugin.lrplugin/UploadHelpers.lua
@@ -121,8 +121,16 @@ local function naiveTime(isoStr)
     if not y then
         return nil
     end
-    local ok, t = pcall(LrDate.timeFromComponents, tonumber(y), tonumber(mo), tonumber(d),
-        tonumber(h), tonumber(mi), tonumber(s), "gmt")
+    local ok, t = pcall(
+        LrDate.timeFromComponents,
+        tonumber(y),
+        tonumber(mo),
+        tonumber(d),
+        tonumber(h),
+        tonumber(mi),
+        tonumber(s),
+        "gmt"
+    )
     if ok then
         return t
     end
@@ -146,13 +154,11 @@ end
 -- caller leaves Immich's own extraction untouched. Capture-time edits land in the
 -- original field, so this still honors "Edit Capture Time".
 function UploadHelpers.captureTimeForImmich(photo)
-    local cocoa = photo:getRawMetadata("dateTimeOriginal")
-        or photo:getRawMetadata("dateTimeDigitized")
+    local cocoa = photo:getRawMetadata("dateTimeOriginal") or photo:getRawMetadata("dateTimeDigitized")
 
     -- Prefer the ISO8601 string (Lightroom's local wall-clock, faithful to the
     -- capture-location zone). Fall back to rendering the numeric field locally.
-    local localIso = photo:getRawMetadata("dateTimeOriginalISO8601")
-        or photo:getRawMetadata("dateTimeDigitizedISO8601")
+    local localIso = photo:getRawMetadata("dateTimeOriginalISO8601") or photo:getRawMetadata("dateTimeDigitizedISO8601")
     if util.nilOrEmpty(localIso) then
         if type(cocoa) ~= "number" then
             return nil

--- a/immich-plugin.lrplugin/UploadHelpers.lua
+++ b/immich-plugin.lrplugin/UploadHelpers.lua
@@ -90,3 +90,93 @@ function UploadHelpers.applyLrStacksInImmich(immich, exportedPrimaryByPhoto, sta
         end
     end
 end
+
+--------------------------------------------------------------------------------
+-- Collect a photo's keywords as Immich tag names, honoring each keyword's
+-- "Include on Export" attribute (the same gate Lightroom uses when embedding
+-- keywords into rendered files).
+function UploadHelpers.collectExportKeywords(photo)
+    local names = {}
+    local keywords = photo:getRawMetadata("keywords")
+    if type(keywords) ~= "table" then
+        return names
+    end
+    for _, keyword in ipairs(keywords) do
+        local attrs = keyword:getAttributes()
+        if attrs == nil or attrs.includeOnExport ~= false then
+            local name = keyword:getName()
+            if not util.nilOrEmpty(name) then
+                table.insert(names, name)
+            end
+        end
+    end
+    return names
+end
+
+--------------------------------------------------------------------------------
+-- Push Lightroom metadata that Immich cannot read from the uploaded file to the
+-- primary asset. Only applied to videos: Lightroom rewrites edited capture date
+-- and keywords into rendered photos (which Immich extracts on ingest) but passes
+-- video containers through untouched, so those edits never reach Immich
+-- otherwise. Best-effort; failures are logged, not fatal.
+function UploadHelpers.applyVideoMetadata(immich, photo, assetId)
+    if not photo or util.nilOrEmpty(assetId) then
+        return
+    end
+    if photo:getRawMetadata("fileFormat") ~= "VIDEO" then
+        return
+    end
+
+    -- Immich probes and thumbnails a freshly uploaded video asynchronously.
+    -- Changing its date here before that finishes races the ingest pipeline and
+    -- leaves the thumbnail in an error state, so wait for it to be ready first.
+    immich:waitForAssetReady(assetId, 30)
+
+    -- Edited capture time. Prefer the original-capture ISO field (reflects
+    -- Lightroom's "Edit Capture Time"), fall back to the adjusted date/time.
+    local isoDate = photo:getRawMetadata("dateTimeOriginalISO8601")
+        or photo:getRawMetadata("dateTimeISO8601")
+    if not util.nilOrEmpty(isoDate) then
+        immich:setAssetDate(assetId, isoDate)
+    end
+
+    -- Keywords -> tags. Additive only: assign the photo's current export keywords
+    -- as tags and never remove any. Tags added directly in Immich are preserved.
+    local tagNames = UploadHelpers.collectExportKeywords(photo)
+    if #tagNames > 0 then
+        local tags = immich:upsertTags(tagNames)
+        if tags then
+            local tagIds = {}
+            for _, tag in ipairs(tags) do
+                if tag.id then
+                    table.insert(tagIds, tag.id)
+                end
+            end
+            if #tagIds > 0 then
+                immich:assignTagsToAsset(tagIds, assetId)
+            end
+        end
+    end
+
+    -- The date change above can invalidate the video's thumbnail (Immich
+    -- regenerates it, and a freshly uploaded or just-replaced asset can be left
+    -- showing an error). The pre-upload wait can't prevent this because the
+    -- breakage is caused by our own edit, and an existing asset already has a
+    -- stale thumbnail that defeats the wait. Queue a regeneration so it recovers.
+    immich:regenerateThumbnail(assetId)
+end
+
+--------------------------------------------------------------------------------
+-- Apply applyVideoMetadata to every successfully-uploaded primary asset. Runs
+-- after all uploads so it lands after replaceAsset's metadata copy. One bad
+-- photo never aborts the batch.
+function UploadHelpers.applyVideoMetadataForAll(immich, exportedPrimaryByPhoto)
+    for _, rec in pairs(exportedPrimaryByPhoto) do
+        local ok, err = LrTasks.pcall(function()
+            UploadHelpers.applyVideoMetadata(immich, rec.photo, rec.assetId)
+        end)
+        if not ok then
+            log:warn("applyVideoMetadata failed: " .. tostring(err))
+        end
+    end
+end

--- a/immich-plugin.lrplugin/UploadHelpers.lua
+++ b/immich-plugin.lrplugin/UploadHelpers.lua
@@ -114,6 +114,32 @@ function UploadHelpers.collectExportKeywords(photo)
 end
 
 --------------------------------------------------------------------------------
+-- Resolve a photo's capture time as a zoned ISO string Immich can store without
+-- shifting it. Lightroom keeps the capture instant as an absolute value, and
+-- LrDate.timeToW3CDate renders it in UTC (DST-aware) but, on some versions,
+-- without a "Z". An Immich value with no zone is assumed to be UTC, so we mark
+-- the UTC rendering with "Z"; if timeToW3CDate already supplies a zone we keep
+-- it. Falls back to the local ISO field when no numeric capture time exists.
+function UploadHelpers.captureTimeForImmich(photo)
+    local cocoa = photo:getRawMetadata("dateTimeOriginal") or photo:getRawMetadata("dateTime")
+    if type(cocoa) == "number" then
+        local w3c = LrDate.timeToW3CDate(cocoa)
+        if w3c and w3c ~= "" then
+            if w3c:match("[Zz]$") or w3c:match("[%+%-]%d%d:?%d%d$") then
+                log:trace("captureTimeForImmich: zoned '" .. w3c .. "'")
+                return w3c
+            end
+            log:trace("captureTimeForImmich: utc '" .. w3c .. "' -> '" .. w3c .. "Z'")
+            return w3c .. "Z"
+        end
+    end
+    local iso = photo:getRawMetadata("dateTimeOriginalISO8601") or photo:getRawMetadata("dateTimeISO8601")
+    log:warn("captureTimeForImmich: no numeric capture time (cocoa=" .. tostring(cocoa)
+        .. "); falling back to local '" .. tostring(iso) .. "'")
+    return iso
+end
+
+--------------------------------------------------------------------------------
 -- Push Lightroom metadata that Immich cannot read from the uploaded file to the
 -- primary asset. Only applied to videos: Lightroom rewrites edited capture date
 -- and keywords into rendered photos (which Immich extracts on ingest) but passes
@@ -132,10 +158,9 @@ function UploadHelpers.applyVideoMetadata(immich, photo, assetId)
     -- leaves the thumbnail in an error state, so wait for it to be ready first.
     immich:waitForAssetReady(assetId, 30)
 
-    -- Edited capture time. Prefer the original-capture ISO field (reflects
-    -- Lightroom's "Edit Capture Time"), fall back to the adjusted date/time.
-    local isoDate = photo:getRawMetadata("dateTimeOriginalISO8601")
-        or photo:getRawMetadata("dateTimeISO8601")
+    -- Edited capture time, as a zoned ISO string so Immich stores the correct
+    -- instant (it assumes UTC for any value lacking a timezone).
+    local isoDate = UploadHelpers.captureTimeForImmich(photo)
     if not util.nilOrEmpty(isoDate) then
         immich:setAssetDate(assetId, isoDate)
     end

--- a/immich-plugin.lrplugin/UploadHelpers.lua
+++ b/immich-plugin.lrplugin/UploadHelpers.lua
@@ -134,35 +134,42 @@ end
 -- infers for the asset, so we send Lightroom's local wall-clock together with an
 -- explicit offset. Immich then displays exactly the wall-clock Lightroom shows,
 -- regardless of the zone it would otherwise infer. The offset is derived from
--- Lightroom itself: local wall-clock (dateTimeOriginalISO8601) minus its UTC
--- rendering (timeToW3CDate), so it matches what Lightroom displays and is
--- DST-aware. Falls back to the raw value if the offset cannot be determined.
+-- Lightroom itself (local wall-clock minus its UTC rendering), so it matches what
+-- Lightroom displays and is DST-aware.
+--
+-- Source priority: the "original capture" field, then "digitized". The adjusted
+-- "dateTime" field is excluded -- for videos Lightroom routinely fills it with a
+-- bogus value (wrong day, unrelated time). Each field has an ISO8601 string and a
+-- numeric variant; for some videos (e.g. .mts) the string is nil while the numeric
+-- one still holds the value Lightroom shows under "Original Date/Time", so we fall
+-- back to the numeric field. Returns nil when nothing usable is present, so the
+-- caller leaves Immich's own extraction untouched. Capture-time edits land in the
+-- original field, so this still honors "Edit Capture Time".
 function UploadHelpers.captureTimeForImmich(photo)
-    -- Diagnostic: which Lightroom field actually holds the displayed capture time?
-    log:trace("captureTimeForImmich fields:"
-        .. " dateTimeOriginalISO8601=" .. tostring(photo:getRawMetadata("dateTimeOriginalISO8601"))
-        .. " dateTimeISO8601=" .. tostring(photo:getRawMetadata("dateTimeISO8601"))
-        .. " dateTimeDigitizedISO8601=" .. tostring(photo:getRawMetadata("dateTimeDigitizedISO8601"))
-        .. " dateCreated(fmt)=" .. tostring(photo:getFormattedMetadata("dateCreated")))
-
-    -- Match the order Lightroom itself uses to show a capture time: original,
-    -- then digitized, then the adjusted dateTime. For some videos (e.g. iPhone
-    -- .mov with no EXIF DateTimeOriginal) the dateTime field holds a bogus value,
-    -- while the digitized field carries the correct, file-embedded capture time.
-    local localIso = photo:getRawMetadata("dateTimeOriginalISO8601")
-        or photo:getRawMetadata("dateTimeDigitizedISO8601")
-        or photo:getRawMetadata("dateTimeISO8601")
-    if util.nilOrEmpty(localIso) then
-        return nil
-    end
-    -- Lightroom already supplied a zone: trust it.
-    if localIso:match("[Zz]$") or localIso:match("[%+%-]%d%d:?%d%d$") then
-        log:trace("captureTimeForImmich: zoned '" .. localIso .. "'")
-        return localIso
-    end
     local cocoa = photo:getRawMetadata("dateTimeOriginal")
         or photo:getRawMetadata("dateTimeDigitized")
-        or photo:getRawMetadata("dateTime")
+
+    -- Prefer the ISO8601 string (Lightroom's local wall-clock, faithful to the
+    -- capture-location zone). Fall back to rendering the numeric field locally.
+    local localIso = photo:getRawMetadata("dateTimeOriginalISO8601")
+        or photo:getRawMetadata("dateTimeDigitizedISO8601")
+    if util.nilOrEmpty(localIso) then
+        if type(cocoa) ~= "number" then
+            return nil
+        end
+        localIso = LrDate.timeToUserFormat(cocoa, "%Y-%m-%dT%H:%M:%S")
+        if util.nilOrEmpty(localIso) then
+            return nil
+        end
+    end
+
+    -- Lightroom already supplied a zone: trust it.
+    if localIso:match("[Zz]$") or localIso:match("[%+%-]%d%d:?%d%d$") then
+        return localIso
+    end
+
+    -- No offset: derive it (DST-aware) from the same instant -- the local
+    -- wall-clock minus its UTC rendering -- and append it.
     if type(cocoa) == "number" then
         local utcIso = LrDate.timeToW3CDate(cocoa)
         local localNaive, utcNaive = naiveTime(localIso), naiveTime(utcIso)
@@ -171,8 +178,6 @@ function UploadHelpers.captureTimeForImmich(photo)
             local sign = offsetSec >= 0 and "+" or "-"
             local mins = math.floor((math.abs(offsetSec) + 30) / 60)
             local offset = string.format("%s%02d:%02d", sign, math.floor(mins / 60), mins % 60)
-            log:trace("captureTimeForImmich: local='" .. localIso .. "' utc='" .. tostring(utcIso)
-                .. "' offset='" .. offset .. "'")
             return localIso .. offset
         end
     end

--- a/immich-plugin.lrplugin/UploadHelpers.lua
+++ b/immich-plugin.lrplugin/UploadHelpers.lua
@@ -114,29 +114,70 @@ function UploadHelpers.collectExportKeywords(photo)
 end
 
 --------------------------------------------------------------------------------
--- Resolve a photo's capture time as a zoned ISO string Immich can store without
--- shifting it. Lightroom keeps the capture instant as an absolute value, and
--- LrDate.timeToW3CDate renders it in UTC (DST-aware) but, on some versions,
--- without a "Z". An Immich value with no zone is assumed to be UTC, so we mark
--- the UTC rendering with "Z"; if timeToW3CDate already supplies a zone we keep
--- it. Falls back to the local ISO field when no numeric capture time exists.
+-- Parse an ISO datetime's calendar components into an LrDate, ignoring any zone.
+-- Used only to diff two such values, so the (consistent) reference zone cancels.
+local function naiveTime(isoStr)
+    local y, mo, d, h, mi, s = (isoStr or ""):match("(%d+)-(%d+)-(%d+)T(%d+):(%d+):(%d+)")
+    if not y then
+        return nil
+    end
+    local ok, t = pcall(LrDate.timeFromComponents, tonumber(y), tonumber(mo), tonumber(d),
+        tonumber(h), tonumber(mi), tonumber(s), "gmt")
+    if ok then
+        return t
+    end
+    return nil
+end
+
+-- Resolve a photo's capture time as a zoned ISO string for Immich. Immich assumes
+-- any value lacking a timezone is UTC and displays it shifted by whatever zone it
+-- infers for the asset, so we send Lightroom's local wall-clock together with an
+-- explicit offset. Immich then displays exactly the wall-clock Lightroom shows,
+-- regardless of the zone it would otherwise infer. The offset is derived from
+-- Lightroom itself: local wall-clock (dateTimeOriginalISO8601) minus its UTC
+-- rendering (timeToW3CDate), so it matches what Lightroom displays and is
+-- DST-aware. Falls back to the raw value if the offset cannot be determined.
 function UploadHelpers.captureTimeForImmich(photo)
-    local cocoa = photo:getRawMetadata("dateTimeOriginal") or photo:getRawMetadata("dateTime")
+    -- Diagnostic: which Lightroom field actually holds the displayed capture time?
+    log:trace("captureTimeForImmich fields:"
+        .. " dateTimeOriginalISO8601=" .. tostring(photo:getRawMetadata("dateTimeOriginalISO8601"))
+        .. " dateTimeISO8601=" .. tostring(photo:getRawMetadata("dateTimeISO8601"))
+        .. " dateTimeDigitizedISO8601=" .. tostring(photo:getRawMetadata("dateTimeDigitizedISO8601"))
+        .. " dateCreated(fmt)=" .. tostring(photo:getFormattedMetadata("dateCreated")))
+
+    -- Match the order Lightroom itself uses to show a capture time: original,
+    -- then digitized, then the adjusted dateTime. For some videos (e.g. iPhone
+    -- .mov with no EXIF DateTimeOriginal) the dateTime field holds a bogus value,
+    -- while the digitized field carries the correct, file-embedded capture time.
+    local localIso = photo:getRawMetadata("dateTimeOriginalISO8601")
+        or photo:getRawMetadata("dateTimeDigitizedISO8601")
+        or photo:getRawMetadata("dateTimeISO8601")
+    if util.nilOrEmpty(localIso) then
+        return nil
+    end
+    -- Lightroom already supplied a zone: trust it.
+    if localIso:match("[Zz]$") or localIso:match("[%+%-]%d%d:?%d%d$") then
+        log:trace("captureTimeForImmich: zoned '" .. localIso .. "'")
+        return localIso
+    end
+    local cocoa = photo:getRawMetadata("dateTimeOriginal")
+        or photo:getRawMetadata("dateTimeDigitized")
+        or photo:getRawMetadata("dateTime")
     if type(cocoa) == "number" then
-        local w3c = LrDate.timeToW3CDate(cocoa)
-        if w3c and w3c ~= "" then
-            if w3c:match("[Zz]$") or w3c:match("[%+%-]%d%d:?%d%d$") then
-                log:trace("captureTimeForImmich: zoned '" .. w3c .. "'")
-                return w3c
-            end
-            log:trace("captureTimeForImmich: utc '" .. w3c .. "' -> '" .. w3c .. "Z'")
-            return w3c .. "Z"
+        local utcIso = LrDate.timeToW3CDate(cocoa)
+        local localNaive, utcNaive = naiveTime(localIso), naiveTime(utcIso)
+        if localNaive and utcNaive then
+            local offsetSec = localNaive - utcNaive
+            local sign = offsetSec >= 0 and "+" or "-"
+            local mins = math.floor((math.abs(offsetSec) + 30) / 60)
+            local offset = string.format("%s%02d:%02d", sign, math.floor(mins / 60), mins % 60)
+            log:trace("captureTimeForImmich: local='" .. localIso .. "' utc='" .. tostring(utcIso)
+                .. "' offset='" .. offset .. "'")
+            return localIso .. offset
         end
     end
-    local iso = photo:getRawMetadata("dateTimeOriginalISO8601") or photo:getRawMetadata("dateTimeISO8601")
-    log:warn("captureTimeForImmich: no numeric capture time (cocoa=" .. tostring(cocoa)
-        .. "); falling back to local '" .. tostring(iso) .. "'")
-    return iso
+    log:warn("captureTimeForImmich: could not derive offset; sending local '" .. localIso .. "' as-is")
+    return localIso
 end
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Lightroom embeds corrected capture dates and keywords into rendered photos, so Immich extracts them on ingest. Videos are passed through unaltered, so that metadata never reaches Immich. After all uploads finish, push it to each video's primary asset over the Immich API.

  - ImmichAPI: add setAssetDate (PUT /assets/{id}), upsertTags + assignTagsToAsset (PUT /tags, /tags/assets), waitForAssetReady, and regenerateThumbnail (POST /assets/jobs)
  - UploadHelpers: add collectExportKeywords (honors each keyword's "Include on Export" flag), applyVideoMetadata, applyVideoMetadataForAll
  - ExportTask/PublishTask: apply video metadata after all uploads, so it runs after replaceAsset's metadata copy

  Scope and behavior:
  - Video-only; photos are untouched and keep relying on embedded metadata.
  - Keyword sync is additive — tags added directly in Immich are never removed. This also means keywords removed in Lightroom are not removed in Immich!
  - Capture date uses dateTimeOriginalISO8601 (full date and time), which Immich persists to a sidecar so it survives metadata re-extraction.

  Thumbnail handling: a date change races Immich's async video ingest and
  can leave the thumbnail in an error state. Wait for the asset to finish
  processing before editing, then queue a thumbnail regeneration afterward,
  which also recovers existing/replaced assets whose stale thumbnail
  defeats the wait.

Closes #127

Co-Authored-By: Claude Opus 4.8