### PR TITLE
fix: restore Immich 3.0 album asset loading and remember last import …

### DIFF
--- a/immich-plugin.lrplugin/ImmichAPI.lua
+++ b/immich-plugin.lrplugin/ImmichAPI.lua
@@ -197,21 +197,27 @@ function ImmichAPI:getAlbumAssets(albumId)
         return nil
     end
 
-    local path = "/albums/" .. albumId
-    local parsedResponse = self:doGetRequest(path)
-
-    if not parsedResponse or not parsedResponse.assets then
-        log:trace("getAlbumAssets: No assets found for album ID: " .. albumId)
-        return nil
-    end
-
     local assets = {}
-    for _, asset in ipairs(parsedResponse.assets) do
-        table.insert(assets, {
-            id = asset.id,
-            originalFileName = asset.originalFileName,
-        })
-    end
+    local page = 1
+    repeat
+        local postBody = { albumIds = { albumId }, page = page, size = 250 }
+        local response = self:doPostRequest("/search/metadata", postBody)
+
+        if not response or type(response) ~= "table" or not response.assets then
+            log:error("getAlbumAssets: search/metadata failed for album ID: " .. albumId .. " (page " .. page .. ")")
+            return nil
+        end
+
+        for _, asset in ipairs(response.assets.items or {}) do
+            table.insert(assets, {
+                id = asset.id,
+                originalFileName = asset.originalFileName,
+            })
+        end
+
+        -- nextPage is a string page number (or nil/JSON null when there are no more pages).
+        page = tonumber(response.assets.nextPage)
+    until not page
 
     log:trace("getAlbumAssets: Retrieved " .. #assets .. " assets for album ID: " .. albumId)
     return assets

--- a/immich-plugin.lrplugin/ImportDialog.lua
+++ b/immich-plugin.lrplugin/ImportDialog.lua
@@ -17,8 +17,17 @@ return {
             return
         end
 
-        -- Set default selected album
+        -- Default to the album chosen last time this dialog ran (matched by name so it
+        -- survives across sessions), falling back to the first album in the list.
         prefs.selectedAlbum = albums[1] and albums[1].value or nil
+        if prefs.lastImportAlbumName then
+            for _, album in ipairs(albums) do
+                if album.title == prefs.lastImportAlbumName then
+                    prefs.selectedAlbum = album.value
+                    break
+                end
+            end
+        end
 
         -- Create the dialog UI
         local f = LrView.osFactory()
@@ -65,6 +74,8 @@ return {
         -- Handle dialog result
         if result == "ok" and prefs.selectedAlbum then
             local albumTitle = getAlbumTitleById(albums, prefs.selectedAlbum)
+            -- Remember this album so it is pre-selected next time the dialog opens.
+            prefs.lastImportAlbumName = albumTitle
             loadAlbumPhotos(prefs.selectedAlbum, albumTitle)
         end
     end),


### PR DESCRIPTION
Immich 3.0 removed the `assets` property from GET /albums/{id}, which broke "Import from Immich" ("Failed to load album assets") and silently broke PublishTask sync/deletion detection.

- getAlbumAssets: fetch assets via paginated POST /search/metadata (albumIds filter), following assets.nextPage.
- getAlbumAssetIds: delegate to getAlbumAssets so it no longer reads the removed album.assets property.

Also I fixed this annoying behavior:
- ImportDialog: remember the last chosen album by name and pre-select it the next time the dialog opens.
