### PR TITLE
feature: Reset Immich asset ID in Lightroom catalog

### DIFF
--- a/docs/wiki/Configuration.md
+++ b/docs/wiki/Configuration.md
@@ -13,7 +13,7 @@ These two fields are required for every workflow (Export, Publish, and Import).
 | **URL** | Full base URL of your Immich server, e.g. `https://immich.example.com`. The plug‑in will auto‑correct common mistakes (missing scheme, trailing slash). Use **Test connection** to verify. |
 | **API Key** | An Immich API key with sufficient permissions. See [API Key Permissions](#api-key-permissions) below. |
 
-For **Export** and **Publish**, these are entered in the Export/Publish Service dialog.  
+For **Export** and **Publish**, these are entered in the Export/Publish Service dialog.
 For **Import**, they are saved globally in plug‑in preferences (accessible via the Import configuration dialog or the plug‑in menu).
 
 ---
@@ -59,7 +59,7 @@ Controls whether raw/original files are uploaded alongside the rendered export. 
 | **Always upload original only (no export)** | Skips the rendered export entirely; only the original is sent. |
 | **Always upload original + rendered export (if edited)** | Always sends the original; also sends the rendered export when the photo has edits. |
 
-> **Tip:** Uploading originals preserves RAW data at the cost of extra storage and upload time.  
+> **Tip:** Uploading originals preserves RAW data at the cost of extra storage and upload time.
 > **Warning:** If your export format is set to **Original** in Lightroom and you select an option that produces a separate export, the plug‑in will warn you because no distinct rendered file will be produced for stacking.
 
 ---
@@ -113,6 +113,12 @@ These settings appear in the **Import from Immich** configuration dialog, and ar
 | **Import Batch Size** | Number of assets downloaded in parallel. Default is `2`. Increase for faster imports on a fast network; decrease if you see timeouts or high memory usage. Must be a positive integer. |
 
 ---
+
+### Resetting Stored Immich Links
+
+The plug‑in stores the Immich asset ID on each Lightroom photo so later exports and publishes can update the existing asset. In some cases the asset ID can be accidentally duplicated and might need to be reset.
+
+To clear an assigned Immich asset ID, select the affected photos in Lightroom and choose **Library → Plug‑in Extras → Reset Immich IDs for selected photos**. After confirmation, the command clears only the stored Immich asset ID from the Lightroom catalog. It does not modify or delete anything on the Immich server. The next export or publish will upload the photo as a new asset.
 
 ### Plug‑in Preferences (Logging)
 

--- a/immich-plugin.lrplugin/Info.lua
+++ b/immich-plugin.lrplugin/Info.lua
@@ -31,6 +31,11 @@ return {
             title = "Immich import configuration",
             file = "ImportConfiguration.lua",
         },
+        {
+            title = "Reset Immich IDs for selected photos",
+            file = "ResetImmichIds.lua",
+            enabledWhen = "photosSelected",
+        },
     },
 
     LrExportMenuItems = {

--- a/immich-plugin.lrplugin/MetadataTask.lua
+++ b/immich-plugin.lrplugin/MetadataTask.lua
@@ -32,6 +32,48 @@ function MetadataTask.setImmichAssetId(photo, assetId)
     return success
 end
 
+-- Clear stored Immich asset IDs for a list of photos in one catalog write operation.
+-- This only changes Lightroom metadata and does not modify assets on the Immich server.
+function MetadataTask.clearImmichAssetIds(photos)
+    -- There is nothing to write when Lightroom has no selected photos.
+    if not photos or #photos == 0 then
+        return 0
+    end
+
+    local catalog = LrApplication.activeCatalog()
+    if not catalog then
+        log:warn("clearImmichAssetIds: Cannot access catalog")
+        return false, "Cannot access the Lightroom catalog."
+    end
+
+    local cleared = 0
+    -- Track callback completion separately because a catalog timeout may not raise an error.
+    local writeCompleted = false
+    local ok, err = LrTasks.pcall(function()
+        -- Use one private write transaction for the whole selection so the catalog is not
+        -- locked and unlocked once per photo.
+        catalog:withPrivateWriteAccessDo(function()
+            for _, photo in ipairs(photos) do
+                if photo then
+                    -- An empty string is the plugin's representation of a cleared asset ID.
+                    photo:setPropertyForPlugin(_PLUGIN, "immichAssetId", "")
+                    cleared = cleared + 1
+                end
+            end
+            writeCompleted = true
+        end, { timeout = 30 })
+    end)
+
+    if not ok or not writeCompleted then
+        local message = ok and "Timed out waiting for the Lightroom catalog." or tostring(err)
+        log:error("clearImmichAssetIds: Failed to clear metadata: " .. message)
+        return false, message
+    end
+
+    log:info("clearImmichAssetIds: Cleared IDs for " .. cleared .. " photos")
+    return cleared
+end
+
 function MetadataTask.getImmichAssetId(photo)
     if not photo then
         return nil

--- a/immich-plugin.lrplugin/ResetImmichIds.lua
+++ b/immich-plugin.lrplugin/ResetImmichIds.lua
@@ -1,0 +1,40 @@
+require("MetadataTask")
+
+return {
+    LrTasks.startAsyncTask(function()
+        local catalog = LrApplication.activeCatalog()
+        -- Capture the current Lightroom selection before displaying any dialogs.
+        local photos = catalog and catalog:getTargetPhotos() or {}
+
+        if #photos == 0 then
+            LrDialogs.message("Reset Immich IDs", "Select at least one photo before running this command.", "warning")
+            return
+        end
+
+        -- This command only changes Lightroom metadata. Confirm the scope before writing
+        -- so a selection mistake cannot silently reset IDs for the wrong photos.
+        local result = LrDialogs.confirm(
+            "Reset Immich IDs?",
+            "This will clear the stored Immich asset ID for "
+                .. #photos
+                .. " selected photo(s). It will not modify or delete anything in Immich.",
+            "Reset",
+            "Cancel"
+        )
+        if result ~= "ok" then
+            return
+        end
+
+        -- The helper function resets the stored Immich asset IDs in the current catalog for all selected photos.
+        local cleared, err = MetadataTask.clearImmichAssetIds(photos)
+        if not cleared then
+            LrDialogs.message("Reset Immich IDs failed", tostring(err), "critical")
+            return
+        end
+
+        LrDialogs.message(
+            "Immich IDs reset",
+            "Cleared stored Immich asset IDs for " .. cleared .. " selected photo(s)."
+        )
+    end),
+}


### PR DESCRIPTION
- Add `Library → Plug-in Extras → Reset Immich IDs for selected photos`
- Clear stored `immichAssetId` values for selected photos in the Lightroom catalog
- This command does not call any Immich APIs, so existing Immich assets are not modified or deleted

Closes #145